### PR TITLE
Fix CI runs and improve test resilience

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -89,6 +89,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ndk-
 
+      - name: Cache native build outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/.cxx
+            app/build/intermediates/cxx
+            app/build/intermediates/cmake
+          key: ${{ runner.os }}-native-build-${{ hashFiles('app/src/main/cpp/**', '**/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-native-build-
+
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:
@@ -150,6 +161,17 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+
+      - name: Restore native build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/.cxx
+            app/build/intermediates/cxx
+            app/build/intermediates/cmake
+          key: ${{ runner.os }}-native-build-${{ hashFiles('app/src/main/cpp/**', '**/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-native-build-
 
       - name: Run Robolectric Unit Tests
         timeout-minutes: 20

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -315,9 +315,10 @@ dependencies {
     // UI Automator for E2E Testing
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
-    androidTestUtil(files("${rootDir}/diagnostic-client-uk/build/outputs/apk/debug/diagnostic-client-uk-debug.apk"))
-    androidTestUtil(files("${rootDir}/diagnostic-client-fr/build/outputs/apk/debug/diagnostic-client-fr-debug.apk"))
-    androidTestUtil(files("${rootDir}/diagnostic-client-direct/build/outputs/apk/debug/diagnostic-client-direct-debug.apk"))
+    // NOTE: Diagnostic client APKs are currently missing from the repository
+    // androidTestUtil(files("${rootDir}/diagnostic-client-uk/build/outputs/apk/debug/diagnostic-client-uk-debug.apk"))
+    // androidTestUtil(files("${rootDir}/diagnostic-client-fr/build/outputs/apk/debug/diagnostic-client-fr-debug.apk"))
+    // androidTestUtil(files("${rootDir}/diagnostic-client-direct/build/outputs/apk/debug/diagnostic-client-direct-debug.apk"))
     
     // Mocking - Using Mockito for Android tests (more reliable than MockK on Android)
     testImplementation("io.mockk:mockk:1.13.10")
@@ -356,12 +357,12 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 }
 
-gradle.projectsEvaluated {
-    tasks.matching { it.name == "connectedDebugAndroidTest" }.configureEach {
-        dependsOn(
-            ":diagnostic-client-uk:assembleDebug",
-            ":diagnostic-client-fr:assembleDebug",
-            ":diagnostic-client-direct:assembleDebug"
-        )
-    }
-}
+// gradle.projectsEvaluated {
+//     tasks.matching { it.name == "connectedDebugAndroidTest" }.configureEach {
+//         dependsOn(
+//             ":diagnostic-client-uk:assembleDebug",
+//             ":diagnostic-client-fr:assembleDebug",
+//             ":diagnostic-client-direct:assembleDebug"
+//         )
+//     }
+// }

--- a/scripts/ci/download-gradle-dependencies.sh
+++ b/scripts/ci/download-gradle-dependencies.sh
@@ -32,7 +32,7 @@ while true; do
       STALL_COUNT=$((STALL_COUNT + 1))
       echo "⚠️  No new output for $((STALL_COUNT * INTERVAL)) seconds"
       
-      if [ $STALL_COUNT -ge 4 ]; then
+      if [ $STALL_COUNT -ge 20 ]; then
         echo "❌ STALLED: No output for $((STALL_COUNT * INTERVAL)) seconds"
         echo "Last 50 lines of output:"
         tail -50 "$LOG_FILE"
@@ -62,24 +62,30 @@ echo "=== Attempting simple dependency resolution first ==="
 # Try a simpler approach: just resolve specific configurations we know we need
 set +e  # Don't exit on error
 
-./gradlew dependencies --configuration debugCompileClasspath --info 2>&1 | tee -a gradle-dependency-download.log
+./gradlew :app:dependencies --configuration debugCompileClasspath --info 2>&1 | tee -a gradle-dependency-download.log
 echo "✓ debugCompileClasspath resolved"
 
-./gradlew dependencies --configuration debugRuntimeClasspath --info 2>&1 | tee -a gradle-dependency-download.log
+./gradlew :app:dependencies --configuration debugRuntimeClasspath --info 2>&1 | tee -a gradle-dependency-download.log
 echo "✓ debugRuntimeClasspath resolved"
 
-./gradlew dependencies --configuration debugAndroidTestCompileClasspath --info 2>&1 | tee -a gradle-dependency-download.log
+./gradlew :app:dependencies --configuration debugAndroidTestCompileClasspath --info 2>&1 | tee -a gradle-dependency-download.log
 echo "✓ debugAndroidTestCompileClasspath resolved"
 
-./gradlew dependencies --configuration debugAndroidTestRuntimeClasspath --info 2>&1 | tee -a gradle-dependency-download.log
+./gradlew :app:dependencies --configuration debugAndroidTestRuntimeClasspath --info 2>&1 | tee -a gradle-dependency-download.log
 echo "✓ debugAndroidTestRuntimeClasspath resolved"
 
 # Now try our custom task
 echo ""
 echo "=== Running androidDependencies task ==="
+
+# Only exclude native build if it's NOT already skipped via environment variable
+EXCLUDE_NATIVE=""
+if [ "$SKIP_NATIVE_BUILD" != "true" ]; then
+  EXCLUDE_NATIVE="-x externalNativeBuildDebug -x externalNativeBuildRelease"
+fi
+
 ./gradlew androidDependencies \
-  -x externalNativeBuildDebug \
-  -x externalNativeBuildRelease \
+  $EXCLUDE_NATIVE \
   --info --stacktrace 2>&1 | tee -a gradle-dependency-download.log
 
 GRADLE_EXIT=$?

--- a/scripts/ci/run-instrumentation-tests.sh
+++ b/scripts/ci/run-instrumentation-tests.sh
@@ -9,7 +9,9 @@ echo "Timestamp: $(date)"
 
 # Run with monitoring
 set +e
-./gradlew connectedDebugAndroidTest -x externalNativeBuildDebug -x externalNativeBuildRelease --info --stacktrace 2>&1 | tee instrumentation-test.log
+# Native builds are NOT excluded here because instrumentation tests (E2E)
+# require native libraries to establish actual VPN connections.
+./gradlew connectedDebugAndroidTest --info --stacktrace 2>&1 | tee instrumentation-test.log
 
 TEST_EXIT=$?
 set -e

--- a/scripts/ci/run-robolectric-tests.sh
+++ b/scripts/ci/run-robolectric-tests.sh
@@ -88,7 +88,10 @@ echo "=== Test Summary ==="
 grep -E "(BUILD SUCCESSFUL|BUILD FAILED|> Task :app:testDebugUnitTest|tests completed|test failed|tests? skipped|SKIPPED)" robolectric-test.log | tail -30 || echo "No test summary found"
 
 # Check for skipped tests
-SKIPPED_COUNT=$(grep -c "SKIPPED" robolectric-test.log || echo "0")
+SKIPPED_COUNT=$(grep -c "SKIPPED" robolectric-test.log || true)
+if [ -z "$SKIPPED_COUNT" ]; then
+  SKIPPED_COUNT=0
+fi
 echo ""
 echo "=== Skipped tests: $SKIPPED_COUNT ==="
 if [ "$SKIPPED_COUNT" -gt "0" ]; then

--- a/scripts/ci/run-robolectric-tests.sh
+++ b/scripts/ci/run-robolectric-tests.sh
@@ -29,7 +29,7 @@ while true; do
       STALL_COUNT=$((STALL_COUNT + 1))
       echo "⚠️  No new test output for $((STALL_COUNT * INTERVAL)) seconds"
       
-      if [ $STALL_COUNT -ge 4 ]; then
+      if [ $STALL_COUNT -ge 20 ]; then
         echo "❌ TESTS STALLED: No output for $((STALL_COUNT * INTERVAL)) seconds"
         echo "Last 100 lines of test output:"
         tail -100 "$LOG_FILE"
@@ -57,9 +57,16 @@ MONITOR_PID=$!
 
 # Run tests with detailed logging
 set +e
+
+# Only exclude native build if it's NOT already skipped via environment variable
+# If SKIP_NATIVE_BUILD=true, the tasks won't exist and -x will fail
+EXCLUDE_NATIVE=""
+if [ "$SKIP_NATIVE_BUILD" != "true" ]; then
+  EXCLUDE_NATIVE="-x externalNativeBuildDebug -x externalNativeBuildRelease"
+fi
+
 ./gradlew testDebugUnitTest \
-  -x externalNativeBuildDebug \
-  -x externalNativeBuildRelease \
+  $EXCLUDE_NATIVE \
   --info --stacktrace 2>&1 | tee robolectric-test.log
 
 TEST_EXIT=$?


### PR DESCRIPTION
This PR fixes multiple issues that were causing the Android CI to fail:

1.  **Gradle Task Errors**: When `SKIP_NATIVE_BUILD=true` is set, the `externalNativeBuild` tasks are not created in `build.gradle.kts`. The CI scripts were unconditionally trying to exclude these tasks (`-x`), causing Gradle to fail. I modified the scripts to only add the exclude flags if native builds are actually enabled.
2.  **aggressive Timeouts**: The monitoring scripts were killing processes after only 2 minutes of silence. This is often not enough for slow CI runners during dependency downloads or complex builds. I increased this to 10 minutes.
3.  **Missing Projects**: References to `diagnostic-client-*` projects were causing configuration failures because those projects are missing from the repository. I commented out these references.
4.  **Native Build Caching**: Added caching for `.cxx` and other native build intermediates to significantly speed up the `cpp-unit-tests` and `build-and-test` jobs.
5.  **Test Resilience**: Instrumentation tests now correctly include native libraries, ensuring that E2E tests can actually establish VPN connections as intended.
6.  **Targeted Dependency Resolution**: Fixed the `dependencies` task call in the CI to correctly target the `:app` module.

---
*PR created automatically by Jules for task [14846907111868339455](https://jules.google.com/task/14846907111868339455) started by @thepont*