### PR TITLE
⚡ Optimize Auto Setup with Batch Queries

### DIFF
--- a/app/src/main/java/com/multiregionvpn/service/AutoRuleService.kt
+++ b/app/src/main/java/com/multiregionvpn/service/AutoRuleService.kt
@@ -9,6 +9,7 @@ import com.multiregionvpn.network.GeoIpService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 /**
@@ -23,15 +24,17 @@ import kotlinx.coroutines.launch
  * - If preset rule matches user's region:
  *   → Ensures no rule exists (defaults to Direct Internet)
  */
-class AutoRuleService(private val context: Context) {
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-    private val database = AppDatabase.getDatabase(context)
-    private val vpnConfigDao = database.vpnConfigDao()
-    private val appRuleDao = database.appRuleDao()
-    private val credsDao = database.providerCredentialsDao()
-    private val presetRuleDao = database.presetRuleDao()
-    private val settingsRepository = SettingsRepository(vpnConfigDao, appRuleDao, credsDao, presetRuleDao)
-    private val geoIpService = GeoIpService()
+class AutoRuleService(
+    private val context: Context,
+    private val settingsRepository: SettingsRepository = SettingsRepository(
+        AppDatabase.getDatabase(context).vpnConfigDao(),
+        AppDatabase.getDatabase(context).appRuleDao(),
+        AppDatabase.getDatabase(context).providerCredentialsDao(),
+        AppDatabase.getDatabase(context).presetRuleDao()
+    ),
+    private val geoIpService: GeoIpService = GeoIpService(),
+    private val serviceScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+) {
     private val packageManager = context.packageManager
     
     fun runAutoSetup() {
@@ -44,20 +47,24 @@ class AutoRuleService(private val context: Context) {
                 }
                 
                 val installedApps = packageManager.getInstalledApplications(PackageManager.GET_META_DATA)
-                val presetRules = settingsRepository.getAllPresetRules()
+
+                // Fetch all data in batch to avoid N+1 queries
+                val presetRulesMap = settingsRepository.getAllPresetRules().associateBy { it.packageName }
+                val existingRulesMap = settingsRepository.appRuleDao.getAllRulesList().associateBy { it.packageName }
+                val vpnConfigsByRegion = settingsRepository.getAllVpnConfigs().first().associateBy { it.regionId }
                 
                 var rulesCreated = 0
                 var rulesRemoved = 0
                 
                 for (app in installedApps) {
-                    val presetRule = presetRules.find { it.packageName == app.packageName }
+                    val presetRule = presetRulesMap[app.packageName]
                     
                     if (presetRule != null) {
-                        val existingRule = settingsRepository.getAppRuleByPackageName(app.packageName)
+                        val existingRule = existingRulesMap[app.packageName]
                         
                         if (presetRule.targetRegionId != userRegion) {
                             // App should use VPN for a different region
-                            val userVpn = settingsRepository.findVpnForRegion(presetRule.targetRegionId)
+                            val userVpn = vpnConfigsByRegion[presetRule.targetRegionId]
                             if (userVpn != null) {
                                 // Check if rule already exists and points to correct VPN
                                 if (existingRule == null || existingRule.vpnConfigId != userVpn.id) {

--- a/app/src/test/java/com/multiregionvpn/service/AutoRuleServiceTest.kt
+++ b/app/src/test/java/com/multiregionvpn/service/AutoRuleServiceTest.kt
@@ -1,0 +1,71 @@
+package com.multiregionvpn.service
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import com.multiregionvpn.data.database.*
+import com.multiregionvpn.data.repository.SettingsRepository
+import com.multiregionvpn.network.GeoIpService
+import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AutoRuleServiceTest {
+
+    @Test
+    fun testRunAutoSetupOptimizedQueryCount() = runTest {
+        val context = mockk<Context>(relaxed = true)
+        val packageManager = mockk<PackageManager>()
+        val settingsRepository = mockk<SettingsRepository>(relaxed = true)
+        val appRuleDao = mockk<AppRuleDao>(relaxed = true)
+        val geoIpService = mockk<GeoIpService>()
+        val testScope = this
+
+        every { context.packageManager } returns packageManager
+        every { settingsRepository.appRuleDao } returns appRuleDao
+
+        // Mock GeoIpService - User is in US
+        coEvery { geoIpService.getCurrentRegion() } returns "US"
+
+        // Mock Package Manager - 10 apps installed
+        val apps = (1..10).map { i ->
+            ApplicationInfo().apply { packageName = "com.app$i" }
+        }
+        every { packageManager.getInstalledApplications(any<Int>()) } returns apps
+
+        // Mock PresetRules
+        val presetRules = apps.map { app ->
+            val region = if (app.packageName.endsWith("1")) "UK" else "US"
+            PresetRule(app.packageName, region)
+        }
+        coEvery { settingsRepository.getAllPresetRules() } returns presetRules
+
+        // Mock existing rules and VPN configs for batch fetching
+        coEvery { appRuleDao.getAllRulesList() } returns emptyList()
+        val vpnUk = VpnConfig("vpn-uk", "UK Server", "UK", "nordvpn", "uk.nordvpn.com")
+        every { settingsRepository.getAllVpnConfigs() } returns kotlinx.coroutines.flow.flowOf(listOf(vpnUk))
+
+        // The service being tested
+        val service = AutoRuleService(context, settingsRepository, geoIpService, testScope)
+
+        // Act
+        service.runAutoSetup()
+        advanceUntilIdle()
+
+        // Assert/Verify optimization
+
+        // 1. Individual queries are NO LONGER called inside the loop
+        verify(exactly = 0) { settingsRepository.getAppRuleByPackageName(any()) }
+        verify(exactly = 0) { settingsRepository.findVpnForRegion(any()) }
+
+        // 2. Batch queries are called instead
+        coVerify(exactly = 1) { appRuleDao.getAllRulesList() }
+        verify(exactly = 1) { settingsRepository.getAllVpnConfigs() }
+
+        println("Optimization verified: 0 individual queries, batch queries used instead.")
+    }
+}


### PR DESCRIPTION
💡 **What:** Optimized `AutoRuleService.runAutoSetup()` by fetching PresetRules, AppRules, and VpnConfigs in batch before the main loop.

🎯 **Why:** The previous implementation performed multiple database queries inside a loop over all installed apps, leading to an N+1 query problem. This caused significant performance degradation as the number of installed apps increased.

📊 **Measured Improvement:**
- Query count for N apps with preset rules reduced from O(N) to O(1) database roundtrips.
- Specifically, the number of read queries was reduced from approximately 1 + 2N to exactly 3.
- Lookup time for preset rules was improved from O(M) to O(1) per app by using a Map instead of searching through a List.
- Verified with a unit test (`AutoRuleServiceTest.kt`) that ensures individual repository/DAO methods are not called inside the loop.

---
*PR created automatically by Jules for task [108941895426598225](https://jules.google.com/task/108941895426598225) started by @thepont*