### PR TITLE
🧹 Remove unused startInboundLoop in VpnEngineService.kt

### DIFF
--- a/app/src/main/java/com/multiregionvpn/core/VpnEngineService.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnEngineService.kt
@@ -908,22 +908,6 @@ class VpnEngineService : VpnService() {
         Log.i(TAG, "📖 readPacketsFromTun() coroutine stopped (read $packetCount packets total)")
     }
     
-    private suspend fun startInboundLoop() {
-        // This loop is no longer needed - packets from tunnels are written
-        // directly via the packet receiver callback set in initializePacketRouter()
-        // We keep this as a placeholder for future enhancements
-        while (vpnInterface != null && serviceScope.isActive) {
-            try {
-                kotlinx.coroutines.delay(1000)
-            } catch (e: Exception) {
-                if (vpnInterface != null) {
-                    Log.e(TAG, "Error in inbound loop", e)
-                }
-                break
-            }
-        }
-    }
-    
     /**
      * Monitors app rules and manages VPN tunnels.
      * Creates tunnels for VPN configs referenced by app rules,


### PR DESCRIPTION
🎯 **What:** Removed the unused private function `startInboundLoop` from `VpnEngineService.kt`.
💡 **Why:** The function was no longer used and its logic was replaced by a packet receiver callback, as noted in the code comments. Removing dead code improves maintainability and readability.
✅ **Verification:** 
- Verified that the function was not called anywhere in the codebase using `grep`.
- Confirmed the function was `private`, so it couldn't be accessed from other files.
- Attempted build/test with Gradle (though environmental timeouts occurred).
✨ **Result:** Cleaner and more maintainable code in `VpnEngineService.kt`.

---
*PR created automatically by Jules for task [838261913795533447](https://jules.google.com/task/838261913795533447) started by @thepont*