### PR TITLE
🛡️ Sentinel: Manifest Security and File Permission Hardening

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+# Sentinel Security Journal 🛡️
+
+## 2026-02-24 - [Hardening] Manifest Security and Credential File Permissions
+**Vulnerability:** The application had `android:allowBackup="true"` and `android:usesCleartextTraffic="true"` in the production manifest, contradicting security best practices and the app's own documentation/memory. Additionally, temporary VPN credential files were created without explicit restricted permissions.
+**Learning:** Even when project documentation or memory indicates a security feature is implemented, the actual codebase may diverge due to regressions or incomplete merges. Configuration-level vulnerabilities (Manifest) are often overlooked but have high impact.
+**Prevention:**
+1. Always explicitly disable backups in production manifests for privacy-sensitive apps.
+2. Use debug manifest overrides for developer-only features like cleartext traffic instead of enabling them globally.
+3. Apply "defense in depth" by setting owner-only filesystem permissions (`chmod 600` equivalent) on sensitive temporary files, even when stored in internal storage.

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,6 +15,8 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:usesCleartextTraffic="true"
+        tools:replace="android:usesCleartextTraffic"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,12 +20,12 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/java/com/multiregionvpn/core/VpnTemplateService.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnTemplateService.kt
@@ -73,6 +73,12 @@ class VpnTemplateService @Inject constructor(
             val authContent = "${creds.username}\n${creds.password}\n"
             authFile.writeText(authContent, Charsets.UTF_8)  // Explicitly use UTF-8
             
+            // Set secure owner-only permissions for the credential file
+            authFile.setReadable(false, false) // Remove all read permissions
+            authFile.setReadable(true, true)  // Set owner-only read
+            authFile.setWritable(false, false) // Remove all write permissions
+            authFile.setWritable(true, true)  // Set owner-only write
+
             // Verify file was written correctly
             val writtenBytes = authFile.length()
             val expectedBytes = authContent.toByteArray(Charsets.UTF_8).size.toLong()
@@ -118,6 +124,13 @@ class VpnTemplateService @Inject constructor(
         withContext(Dispatchers.IO) {
             val authContent = "${creds.username}\n${creds.password}\n"
             authFile.writeText(authContent, Charsets.UTF_8)
+
+            // Set secure owner-only permissions for the credential file
+            authFile.setReadable(false, false)
+            authFile.setReadable(true, true)
+            authFile.setWritable(false, false)
+            authFile.setWritable(true, true)
+
             Log.d(TAG, "Local test auth file created: ${authFile.absolutePath}")
         }
         


### PR DESCRIPTION
This PR implements several security hardening measures for the Multi-Region VPN application.

1. **Manifest Hardening**: 
   - Disables ADB/Cloud backups (\`android:allowBackup="false"\`) to prevent extraction of sensitive VPN configurations and credentials.
   - Enforces encrypted traffic (\`android:usesCleartextTraffic="false"\`) by default in production.
   - Correctly provides a debug override in \`app/src/debug/AndroidManifest.xml\` to allow cleartext traffic only for local testing (required by Maestro E2E tests).

2. **File Permission Hardening**:
   - Updates \`VpnTemplateService.kt\` to explicitly set owner-only read/write permissions on temporary authentication files. This ensures that these sensitive files are not readable by other processes on the device, providing defense-in-depth for user credentials.

3. **Security Journal**:
   - Initiated the Sentinel security journal in \`.jules/sentinel.md\` to track these improvements and learnings.

These changes align with the security goals of the project and follow Android security best practices.

---
*PR created automatically by Jules for task [17748655149805321768](https://jules.google.com/task/17748655149805321768) started by @thepont*