### PR TITLE
🛡️ Sentinel: Security Hardening and Info Leakage Prevention

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,12 +20,12 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/java/com/multiregionvpn/core/VpnError.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnError.kt
@@ -83,7 +83,9 @@ data class VpnError(
     companion object {
         fun fromException(e: Throwable, tunnelId: String? = null): VpnError {
             val errorMsg = e.message ?: "Unknown error"
-            val details = e.stackTraceToString()
+            // Use exception message as details instead of full stack trace
+            // to prevent leaking internal implementation details to the user.
+            val details = e.message
             
             return when {
                 errorMsg.contains("auth", ignoreCase = true) ||

--- a/app/src/test/java/com/multiregionvpn/core/VpnErrorTest.kt
+++ b/app/src/test/java/com/multiregionvpn/core/VpnErrorTest.kt
@@ -1,0 +1,37 @@
+package com.multiregionvpn.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class VpnErrorTest {
+
+    @Test
+    fun `fromException should not include stack trace in details`() {
+        val exception = RuntimeException("Sensitive error message")
+        val vpnError = VpnError.fromException(exception)
+
+        assertEquals("Sensitive error message", vpnError.message)
+        assertEquals("Sensitive error message", vpnError.details)
+
+        // Ensure stack trace info is NOT present in details
+        val stackTrace = exception.stackTraceToString()
+        assertFalse("Details should not contain stack trace info", vpnError.details!!.contains("at com.multiregionvpn"))
+    }
+
+    @Test
+    fun `fromException should map authentication errors correctly`() {
+        val exception = RuntimeException("authentication failed for user")
+        val vpnError = VpnError.fromException(exception)
+
+        assertEquals(VpnError.ErrorType.AUTHENTICATION_FAILED, vpnError.type)
+    }
+
+    @Test
+    fun `fromException should map connection errors correctly`() {
+        val exception = RuntimeException("connection timeout to server")
+        val vpnError = VpnError.fromException(exception)
+
+        assertEquals(VpnError.ErrorType.CONNECTION_FAILED, vpnError.type)
+    }
+}


### PR DESCRIPTION
This PR implements several security hardening measures:

1. **Manifest Hardening**: Set `android:allowBackup="false"` in `AndroidManifest.xml` to prevent VPN credentials from being extracted via system backups.
2. **Network Security**: Set `android:usesCleartextTraffic="false"` to enforce encrypted communication (HTTPS/TLS) by default. Exceptions for `ip-api.com` are already managed in `network_security_config.xml`.
3. **Information Disclosure Prevention**: Updated `VpnError.fromException` to use `e.message` instead of `e.stackTraceToString()` for the `details` field. This prevents leaking internal implementation details and stack traces to the user or logs.
4. **Verification**: Added `VpnErrorTest.kt` to ensure the stack trace is correctly excluded from error details and that error mapping still works.

All unit tests passed using Java 17.

---
*PR created automatically by Jules for task [1049920699583186455](https://jules.google.com/task/1049920699583186455) started by @thepont*