### PR TITLE
🛡️ Sentinel: Harden application security and fix info leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,11 @@
+# Sentinel Security Journal 🛡️
+
+## 2025-05-15 - [Vulnerability] Stack Trace Leakage in VpnError
+**Vulnerability:** The `VpnError.fromException()` method was using `e.stackTraceToString()` to populate the `details` field, which is subsequently displayed to users in the UI via `getUserMessage()`.
+**Learning:** Stack traces can reveal internal package structures, library versions, and potentially sensitive code logic, providing attackers with valuable information for exploitation.
+**Prevention:** Always sanitize error messages intended for the UI. Use `e.message` for high-level details and keep stack traces in secure, internal logs only.
+
+## 2025-05-15 - [Enhancement] Hardening Android Application Configuration
+**Vulnerability:** The application had `android:allowBackup="true"` and `android:usesCleartextTraffic="true"` in the main manifest.
+**Learning:** `allowBackup="true"` allows sensitive data (like VPN credentials in Room DB) to be extracted via `adb backup`. `usesCleartextTraffic="true"` allows unencrypted HTTP traffic globally, increasing the risk of MitM attacks.
+**Prevention:** Disable backups for apps handling sensitive credentials. Enforce HTTPS by default and use `network_security_config.xml` for granular cleartext exceptions (e.g., local testing or specific APIs). Use the debug manifest to re-enable cleartext for developer tools/agents like Maestro.

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,6 +15,9 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:usesCleartextTraffic="true"
+        tools:targetApi="23"
+        tools:replace="android:usesCleartextTraffic"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -16,8 +16,9 @@
 
     <application
         android:usesCleartextTraffic="true"
+        android:allowBackup="true"
         tools:targetApi="23"
-        tools:replace="android:usesCleartextTraffic"
+        tools:replace="android:usesCleartextTraffic,android:allowBackup"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow all cleartext traffic in debug builds for Maestro and other developer tools -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,12 +20,12 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/java/com/multiregionvpn/core/VpnError.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnError.kt
@@ -83,7 +83,8 @@ data class VpnError(
     companion object {
         fun fromException(e: Throwable, tunnelId: String? = null): VpnError {
             val errorMsg = e.message ?: "Unknown error"
-            val details = e.stackTraceToString()
+            // SECURITY: Use e.message instead of e.stackTraceToString() to avoid leaking internal implementation details
+            val details = e.message
             
             return when {
                 errorMsg.contains("auth", ignoreCase = true) ||

--- a/app/src/test/java/com/multiregionvpn/core/VpnErrorSecurityTest.kt
+++ b/app/src/test/java/com/multiregionvpn/core/VpnErrorSecurityTest.kt
@@ -1,0 +1,39 @@
+package com.multiregionvpn.core
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class VpnErrorSecurityTest {
+
+    @Test
+    fun `fromException should not include stack trace in details`() {
+        val exception = RuntimeException("Sensitive error message")
+        val tunnelId = "test_tunnel"
+
+        val error = VpnError.fromException(exception, tunnelId)
+
+        // Ensure details matches message, not stack trace
+        assertEquals(exception.message, error.details)
+
+        // Additional check: ensure it doesn't contain common stack trace markers
+        val details = error.details ?: ""
+        assertFalse(details.contains("at com.multiregionvpn"), "Details should not contain stack trace info")
+        assertFalse(details.contains(".kt:"), "Details should not contain file line references")
+    }
+
+    @Test
+    fun `fromException should handle null message gracefully`() {
+        val exception = RuntimeException()
+        val error = VpnError.fromException(exception)
+
+        // When e.message is null:
+        // errorMsg becomes "Unknown error"
+        // details becomes e.message which is null
+        assertNotNull(error.message)
+        assertEquals("Unknown error", error.message)
+        assertNull(error.details)
+    }
+}


### PR DESCRIPTION
This PR implements several security hardenings and fixes a potential information leakage vulnerability:

1. **Information Leakage Fix**: The `VpnError` class was previously including full stack traces in the `details` field, which are displayed to users in the UI. This could leak internal implementation details. I've updated it to use `e.message` instead, ensuring only high-level error information is exposed.
2. **Backup Security**: I've disabled Android's automatic backup feature (`android:allowBackup="false"`) in the main manifest. This is a critical security step for VPN applications that handle sensitive user credentials and configurations, as it prevents this data from being extracted via `adb backup`.
3. **Network Security**: I've disabled global cleartext traffic (`android:usesCleartextTraffic="false"`) in the main manifest to enforce secure HTTPS communication by default. 
4. **Developer Compatibility**: To ensure Maestro E2E tests and developer tools still function correctly (which often require cleartext communication over local ports), I've added a debug-specific manifest override that re-enables cleartext traffic only for debug builds.
5. **Security Verification**: I've added a new unit test class `VpnErrorSecurityTest.kt` to ensure that stack traces are never included in the error details.
6. **Security Journaling**: I've initiated a Sentinel security journal in `.jules/sentinel.md` to document these findings and prevent regressions.

All core unit tests were run and passed.

---
*PR created automatically by Jules for task [10146951155384019201](https://jules.google.com/task/10146951155384019201) started by @thepont*