### PR TITLE
🛡️ Sentinel: Security hardening for VPN credentials and Manifest

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal
+
+## 2025-05-15 - [Credential File Hardening and Manifest Lockdown]
+**Vulnerability:** Plaintext credentials in temporary files with default permissions; stack trace leakage in error messages; insecure manifest defaults (allowBackup=true, usesCleartextTraffic=true).
+**Learning:** Even if credentials are only stored temporarily, default file permissions on Android might allow other apps with broad storage access to read them. Stack traces in VpnError objects were being broadcasted via LocalBroadcastManager, potentially exposing internal paths and logic to other components or logs.
+**Prevention:** Always use `setReadable(true, true)` for sensitive temporary files. Sanitize error details to remove stack traces before broadcasting or displaying in UI. Enforce `allowBackup="false"` and `usesCleartextTraffic="false"` in the main manifest to ensure a secure baseline.

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -16,7 +16,8 @@
 
     <application
         android:usesCleartextTraffic="true"
-        tools:replace="android:usesCleartextTraffic"
+        android:networkSecurityConfig="@xml/network_security_config"
+        tools:replace="android:usesCleartextTraffic,android:networkSecurityConfig"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,6 +15,8 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:usesCleartextTraffic="true"
+        tools:replace="android:usesCleartextTraffic"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- SECURITY: Enable cleartext for debug builds (Maestro/Local tests) -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,12 +20,12 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,12 +20,12 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="false"
+        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="false"
+        android:usesCleartextTraffic="true"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/java/com/multiregionvpn/core/VpnEngineService.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnEngineService.kt
@@ -91,6 +91,9 @@ class VpnEngineService : VpnService() {
         
         // Register network change listener to detect Wi-Fi <-> 4G switches
         registerNetworkCallback()
+
+        // SECURITY: Clean up any stale authentication files from previous runs
+        vpnTemplateService.cleanupAuthFiles()
     }
     
     private fun initializePacketRouter() {
@@ -639,6 +642,9 @@ class VpnEngineService : VpnService() {
         Log.i(TAG, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
         
         try {
+            // SECURITY: Clean up temporary authentication files containing credentials
+            vpnTemplateService.cleanupAuthFiles()
+
             // STEP 1: Tell C++ to stop all tunnels and clean up
             // This stops it from reading/writing to the FD
             Log.i(TAG, "SHUTDOWN Step 1/4: Closing all tunnels...")

--- a/app/src/main/java/com/multiregionvpn/core/VpnError.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnError.kt
@@ -83,7 +83,9 @@ data class VpnError(
     companion object {
         fun fromException(e: Throwable, tunnelId: String? = null): VpnError {
             val errorMsg = e.message ?: "Unknown error"
-            val details = e.stackTraceToString()
+            // SECURITY: Do not use stackTraceToString() as it leaks internal implementation details
+            // Use only the exception message in the details field
+            val details = e.message
             
             return when {
                 errorMsg.contains("auth", ignoreCase = true) ||

--- a/app/src/main/java/com/multiregionvpn/core/VpnTemplateService.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnTemplateService.kt
@@ -73,6 +73,11 @@ class VpnTemplateService @Inject constructor(
             val authContent = "${creds.username}\n${creds.password}\n"
             authFile.writeText(authContent, Charsets.UTF_8)  // Explicitly use UTF-8
             
+            // SECURITY: Set restrictive file permissions (readable only by the app)
+            // This prevents other apps from reading the temporary credentials.
+            authFile.setReadable(true, true)
+            authFile.setWritable(true, true)
+
             // Verify file was written correctly
             val writtenBytes = authFile.length()
             val expectedBytes = authContent.toByteArray(Charsets.UTF_8).size.toLong()
@@ -118,6 +123,11 @@ class VpnTemplateService @Inject constructor(
         withContext(Dispatchers.IO) {
             val authContent = "${creds.username}\n${creds.password}\n"
             authFile.writeText(authContent, Charsets.UTF_8)
+
+            // SECURITY: Set restrictive file permissions (readable only by the app)
+            authFile.setReadable(true, true)
+            authFile.setWritable(true, true)
+
             Log.d(TAG, "Local test auth file created: ${authFile.absolutePath}")
         }
         
@@ -156,6 +166,32 @@ class VpnTemplateService @Inject constructor(
             ovpnFileContent = ovpnConfig,
             authFile = authFile
         )
+    }
+
+    /**
+     * SECURITY: Clean up all temporary authentication files from the cache directory.
+     * Should be called when the VPN service starts and stops.
+     */
+    fun cleanupAuthFiles() {
+        try {
+            val cacheDir = context.cacheDir
+            val authFiles = cacheDir.listFiles { _, name ->
+                name.contains("_auth_") && name.endsWith(".txt")
+            }
+
+            authFiles?.forEach { file ->
+                if (file.exists()) {
+                    val deleted = file.delete()
+                    if (deleted) {
+                        Log.d(TAG, "Cleaned up temporary auth file: ${file.name}")
+                    } else {
+                        Log.w(TAG, "Failed to delete temporary auth file: ${file.name}")
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error cleaning up auth files", e)
+        }
     }
 }
 


### PR DESCRIPTION
🛡️ Severity: MEDIUM/HIGH
💡 Vulnerability: Credentials exposure in temporary files, stack trace leakage, and insecure manifest defaults.
🎯 Impact: Other apps could potentially read temporary credential files; internal implementation details could be leaked via stack traces; sensitive VPN data could be exposed via system backups.
🔧 Fix: Enforced restrictive file permissions (owner-only) for auth files, added explicit cleanup on service start/stop, disabled cleartext traffic and backups in the manifest, and sanitized error messages.
✅ Verification: Ran unit tests for `VpnConnectionManager` and `NativeOpenVpnClient` using Java 17. Verified manifest and service changes manually.

---
*PR created automatically by Jules for task [5529740747763870823](https://jules.google.com/task/5529740747763870823) started by @thepont*