### PR TITLE
🛡️ Sentinel: Security Hardening and Information Leakage Fix

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2025-03-03 - [Preventing Information Leakage in VPN Errors]
+**Vulnerability:** Exposed internal stack traces in the `VpnError` class through the `details` field.
+**Learning:** Stack traces contain sensitive information about the app's structure and libraries.
+**Prevention:** Avoid using `e.stackTraceToString()` in user-facing error objects. Use `e.message` or a safe summary instead.
+
+## 2025-03-03 - [Hardening Manifest Security Settings]
+**Vulnerability:** Overly permissive `allowBackup` and `usesCleartextTraffic` settings in `AndroidManifest.xml`.
+**Learning:** Default settings can expose sensitive data to system backups or Man-in-the-Middle (MITM) attacks.
+**Prevention:** Always set `android:allowBackup="false"` and `android:usesCleartextTraffic="false"` for security-sensitive applications, with specific exceptions in `network_security_config.xml` if needed.

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,7 +15,9 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
-        tools:ignore="MissingLeanbackLauncher">
+        android:usesCleartextTraffic="true"
+        tools:ignore="MissingLeanbackLauncher"
+        tools:replace="android:usesCleartextTraffic">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"
             android:exported="true"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,9 +15,12 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:name=".MainApplication"
+        android:label="@string/app_name"
+        android:theme="@style/Theme.MultiRegionVPN"
         android:usesCleartextTraffic="true"
         tools:ignore="MissingLeanbackLauncher"
-        tools:replace="android:usesCleartextTraffic">
+        tools:replace="android:theme,android:name,android:label,android:usesCleartextTraffic">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"
             android:exported="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,12 +20,12 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/java/com/multiregionvpn/core/VpnError.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnError.kt
@@ -83,7 +83,7 @@ data class VpnError(
     companion object {
         fun fromException(e: Throwable, tunnelId: String? = null): VpnError {
             val errorMsg = e.message ?: "Unknown error"
-            val details = e.stackTraceToString()
+            val details = e.message // Avoid leaking stack traces in details
             
             return when {
                 errorMsg.contains("auth", ignoreCase = true) ||

--- a/app/src/test/java/com/multiregionvpn/core/VpnErrorSecurityTest.kt
+++ b/app/src/test/java/com/multiregionvpn/core/VpnErrorSecurityTest.kt
@@ -1,0 +1,32 @@
+package com.multiregionvpn.core
+
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class VpnErrorSecurityTest {
+
+    @Test
+    fun `fromException should not include stack trace in details`() {
+        val exception = RuntimeException("Sensitive error occurred")
+        val vpnError = VpnError.fromException(exception)
+
+        val details = vpnError.details ?: ""
+
+        // Stack traces usually contain class names and line numbers like "at com.multiregionvpn..."
+        assertFalse(details.contains("at "), "Error details should not contain stack trace markers ('at ')")
+        assertFalse(details.contains("VpnErrorSecurityTest.kt"), "Error details should not contain file names from stack trace")
+    }
+
+    @Test
+    fun `fromException should include message but not full trace`() {
+        val message = "Authentication failed"
+        val exception = RuntimeException(message)
+        val vpnError = VpnError.fromException(exception)
+
+        assertTrue(vpnError.message.contains(message), "Error message should be preserved")
+
+        val details = vpnError.details ?: ""
+        assertFalse(details.length > 500, "Error details are too long, likely contains a stack trace")
+    }
+}


### PR DESCRIPTION
This PR implements several security enhancements to the Multi-Region VPN application:

1.  **Manifest Hardening**: 
    - Set `android:allowBackup="false"` to prevent sensitive VPN data from being extracted via system backups.
    - Set `android:usesCleartextTraffic="false"` to enforce TLS for all network connections, mitigating MITM risks (exceptions for `ip-api.com` are maintained in `network_security_config.xml`).

2.  **Information Leakage Prevention**:
    - Updated `VpnError.fromException` to stop using `e.stackTraceToString()`. This prevents internal application details from being exposed in logs or the UI.

3.  **Security Verification**:
    - Added a new unit test `VpnErrorSecurityTest.kt` to ensure that stack traces are not leaked in the `details` field of `VpnError` objects.

These changes follow the "Sentinel" mission to improve the application's security posture through defense-in-depth.

---
*PR created automatically by Jules for task [16841879823361798207](https://jules.google.com/task/16841879823361798207) started by @thepont*