### PR TITLE
🛡️ Sentinel: Security Hardening & Info Leak Fix

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Information leakage through stack traces in VPN error messages, and insecure default manifest settings (backups enabled, cleartext traffic permitted).
 **Learning:** Generic error handling in Android often defaults to exposing full stack traces for debugging, which can leak internal implementation details to users or attackers. Manifest defaults like `android:allowBackup="true"` and `android:usesCleartextTraffic="true"` are often left as-is, increasing the attack surface.
 **Prevention:** Always sanitize exception details before exposing them to the UI. Harden the `AndroidManifest.xml` by explicitly disabling backups and cleartext traffic, using `network_security_config.xml` for necessary exceptions.
+## 2026-03-04 - [Maestro E2E Cleartext Traffic]
+**Vulnerability:** N/A (Functional regression caused by security hardening)
+**Learning:** Maestro E2E tests require cleartext traffic to communicate with the device agent over local ports. Disabling it globally in `AndroidManifest.xml` breaks these tests.
+**Prevention:** Use build variants to apply strict security settings. Keep `android:usesCleartextTraffic="false"` in `main/AndroidManifest.xml` for production, but override it with `true` in `debug/AndroidManifest.xml` for testing tools.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-04 - [Information Leak & Manifest Hardening]
+**Vulnerability:** Information leakage through stack traces in VPN error messages, and insecure default manifest settings (backups enabled, cleartext traffic permitted).
+**Learning:** Generic error handling in Android often defaults to exposing full stack traces for debugging, which can leak internal implementation details to users or attackers. Manifest defaults like `android:allowBackup="true"` and `android:usesCleartextTraffic="true"` are often left as-is, increasing the attack surface.
+**Prevention:** Always sanitize exception details before exposing them to the UI. Harden the `AndroidManifest.xml` by explicitly disabling backups and cleartext traffic, using `network_security_config.xml` for necessary exceptions.

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,12 +15,9 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
-        android:name=".MainApplication"
-        android:theme="@style/Theme.MultiRegionVPN"
-        android:label="@string/app_name"
         android:allowBackup="true"
         android:usesCleartextTraffic="true"
-        tools:replace="android:allowBackup,android:usesCleartextTraffic,android:theme,android:name,android:label"
+        tools:replace="android:allowBackup,android:usesCleartextTraffic"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,6 +15,8 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:usesCleartextTraffic="true"
+        tools:replace="android:usesCleartextTraffic"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,8 +15,12 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:name=".MainApplication"
+        android:theme="@style/Theme.MultiRegionVPN"
+        android:label="@string/app_name"
+        android:allowBackup="true"
         android:usesCleartextTraffic="true"
-        tools:replace="android:usesCleartextTraffic"
+        tools:replace="android:allowBackup,android:usesCleartextTraffic,android:theme,android:name,android:label"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow cleartext traffic for local testing (Maestro E2E) -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <!-- Explicitly allow ip-api.com cleartext as well -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">ip-api.com</domain>
+    </domain-config>
+</network-security-config>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,12 +20,12 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/java/com/multiregionvpn/core/VpnError.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnError.kt
@@ -83,7 +83,7 @@ data class VpnError(
     companion object {
         fun fromException(e: Throwable, tunnelId: String? = null): VpnError {
             val errorMsg = e.message ?: "Unknown error"
-            val details = e.stackTraceToString()
+            val details = e.message // Avoid leaking stack traces in UI
             
             return when {
                 errorMsg.contains("auth", ignoreCase = true) ||

--- a/app/src/test/java/com/multiregionvpn/core/VpnErrorSecurityTest.kt
+++ b/app/src/test/java/com/multiregionvpn/core/VpnErrorSecurityTest.kt
@@ -1,0 +1,35 @@
+package com.multiregionvpn.core
+
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class VpnErrorSecurityTest {
+
+    @Test
+    fun `fromException should not leak stack trace in details`() {
+        val exception = RuntimeException("Sensitive error message")
+        val vpnError = VpnError.fromException(exception)
+
+        val stackTraceIndicator = "VpnErrorSecurityTest"
+
+        // This test is expected to FAIL before the fix
+        assertFalse(
+            vpnError.details?.contains(stackTraceIndicator) ?: false,
+            "VpnError.details should NOT contain the stack trace"
+        )
+    }
+
+    @Test
+    fun `fromException should not leak stack trace in message`() {
+        val exception = RuntimeException("Sensitive error message")
+        val vpnError = VpnError.fromException(exception)
+
+        val stackTraceIndicator = "VpnErrorSecurityTest"
+
+        assertFalse(
+            vpnError.message.contains(stackTraceIndicator),
+            "VpnError.message should NOT contain the stack trace"
+        )
+    }
+}


### PR DESCRIPTION
This submission improves the application's security posture by addressing multiple common vulnerabilities:

1. **Information Leakage Fix**: Modified `VpnError.fromException` to avoid exposing full stack traces in the UI or logs. A new unit test `VpnErrorSecurityTest` verifies that stack traces are not leaked.
2. **Manifest Hardening**:
   - Disabled `android:allowBackup` to prevent sensitive VPN configurations or credentials from being extracted via ADB backups.
   - Set `android:usesCleartextTraffic` to `false` to enforce secure (HTTPS) communication by default, relying on the existing `network_security_config.xml` for necessary exceptions (e.g., `ip-api.com`).
3. **Security Journaling**: Documented the findings and fixes in `.jules/sentinel.md` as per Sentinel's mission protocols.

---
*PR created automatically by Jules for task [350235529607276004](https://jules.google.com/task/350235529607276004) started by @thepont*