### PR TITLE
🛡️ Sentinel: Harden manifest security and fix information disclosure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2026-03-12 - Information Disclosure in VpnError
+**Vulnerability:** `VpnError.fromException()` was using `e.stackTraceToString()` to populate the `details` field, which is displayed to users in the UI via `getUserMessage()`.
+**Learning:** Stack traces can reveal internal application structure, file paths, and library versions, which helps an attacker map the attack surface.
+**Prevention:** Always sanitize exception data before exposing it to the UI. Use `e.message` or generic error categories instead of full stack traces.
+
+## 2026-03-12 - Insecure Default Manifest Configuration
+**Vulnerability:** The production manifest had `android:allowBackup="true"` and `android:usesCleartextTraffic="true"` by default.
+**Learning:** VPN applications handle extremely sensitive data (credentials, keys). Allowing ADB backups can lead to credential theft if a device is temporarily accessed. Allowing cleartext traffic globally increases the risk of MitM attacks if developers accidentally use HTTP for sensitive APIs.
+**Prevention:** Explicitly disable `allowBackup` and `usesCleartextTraffic` in the main manifest. Use debug-specific manifest overrides and `network_security_config.xml` to enable these features only for development/testing environments.

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,6 +15,13 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:name=".MainApplication"
+        android:theme="@style/Theme.MultiRegionVPN"
+        android:label="@string/app_name"
+        android:allowBackup="true"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:usesCleartextTraffic="true"
+        tools:replace="android:allowBackup,android:networkSecurityConfig,android:usesCleartextTraffic,android:theme,android:name,android:label"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,7 +15,7 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
-        android:name=".MainApplication"
+        android:name="com.multiregionvpn.MainApplication"
         android:theme="@style/Theme.MultiRegionVPN"
         android:label="@string/app_name"
         android:allowBackup="true"

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">ip-api.com</domain>
+    </domain-config>
+</network-security-config>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,12 +20,12 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:required="false" />
 
     <application
-        android:name=".MainApplication"
+        android:name="com.multiregionvpn.MainApplication"
         android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
@@ -28,7 +28,7 @@
         android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
-        tools:replace="android:theme,android:name,android:label">
+        tools:replace="android:allowBackup,android:networkSecurityConfig,android:usesCleartextTraffic,android:theme,android:name,android:label">
         
         <!-- Mobile Activity -->
         <activity

--- a/app/src/main/java/com/multiregionvpn/core/VpnError.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnError.kt
@@ -83,7 +83,8 @@ data class VpnError(
     companion object {
         fun fromException(e: Throwable, tunnelId: String? = null): VpnError {
             val errorMsg = e.message ?: "Unknown error"
-            val details = e.stackTraceToString()
+            // Use e.message instead of e.stackTraceToString() to avoid leaking internals
+            val details = e.message ?: e.javaClass.simpleName
             
             return when {
                 errorMsg.contains("auth", ignoreCase = true) ||

--- a/app/src/main/java/com/multiregionvpn/core/vpnclient/NativeOpenVpnClient.kt
+++ b/app/src/main/java/com/multiregionvpn/core/vpnclient/NativeOpenVpnClient.kt
@@ -147,15 +147,10 @@ class NativeOpenVpnClient(
                                 return@withContext false
                             }
                             
-                            // Log encoding info (without exposing actual credentials)
-                            val usernameBytes = username.toByteArray(Charsets.UTF_8)
-                            val passwordBytes = password.toByteArray(Charsets.UTF_8)
-                            Log.d(TAG, "Credentials loaded from auth file (UTF-8):")
-                            Log.d(TAG, "   Username: ${username.length} chars, ${usernameBytes.size} UTF-8 bytes")
-                            Log.d(TAG, "   Password: ${password.length} chars, ${passwordBytes.size} UTF-8 bytes")
-                            
-                            // Verify UTF-8 encoding is valid
+                            // Verify UTF-8 encoding is valid without logging sensitive metadata
                             try {
+                                val usernameBytes = username.toByteArray(Charsets.UTF_8)
+                                val passwordBytes = password.toByteArray(Charsets.UTF_8)
                                 // Attempt to decode as UTF-8 to verify encoding
                                 String(usernameBytes, Charsets.UTF_8)
                                 String(passwordBytes, Charsets.UTF_8)

--- a/app/src/test/java/com/multiregionvpn/core/VpnErrorSecurityTest.kt
+++ b/app/src/test/java/com/multiregionvpn/core/VpnErrorSecurityTest.kt
@@ -1,0 +1,32 @@
+package com.multiregionvpn.core
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VpnErrorSecurityTest {
+
+    @Test
+    fun `fromException should not leak stack trace in details`() {
+        val exception = RuntimeException("Sensitive error message")
+        val vpnError = VpnError.fromException(exception)
+
+        val details = vpnError.details ?: ""
+
+        // This is expected to FAIL before the fix
+        // Stack traces usually contain "at com.multiregionvpn..."
+        assertFalse("Stack trace should not be present in details: $details",
+            details.contains("at ") && details.contains("VpnErrorSecurityTest"))
+    }
+
+    @Test
+    fun `fromException should contain message in details instead of stack trace`() {
+        val message = "Auth failed"
+        val exception = RuntimeException(message)
+        val vpnError = VpnError.fromException(exception)
+
+        // This will verify that we still have some useful info, just not the stack trace
+        assertTrue("Details should contain message or class name",
+            vpnError.details?.contains(message) == true || vpnError.details?.contains("RuntimeException") == true)
+    }
+}


### PR DESCRIPTION
This PR addresses three security concerns in the codebase:

1. **Information Disclosure**: `VpnError.fromException()` was including the full stack trace in its `details` field, which could be exposed to users in the UI. I modified it to use the exception message or class name instead.
2. **Insecure Data Backups**: The production manifest had `android:allowBackup="true"`, which could allow sensitive VPN credentials to be leaked via ADB. I changed this to `false` for production and provided a debug override.
3. **Cleartext Traffic**: The production manifest allowed cleartext HTTP traffic globally. I disabled this and provided a granular debug override for `ip-api.com` and `localhost` to support existing development and E2E testing requirements.

Verification:
- Added `VpnErrorSecurityTest.kt` to verify stack trace is not present in error details.
- Verified that all core unit tests pass.
- Inspected manifests to ensure correct attributes and `tools:replace` usage.

---
*PR created automatically by Jules for task [17941645742815806565](https://jules.google.com/task/17941645742815806565) started by @thepont*