### PR TITLE
🛡️ Sentinel: Fix stack trace leakage in VpnError

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal
+
+## 2025-05-14 - Information Exposure through Stack Traces
+**Vulnerability:** The `VpnError.fromException()` method used `e.stackTraceToString()` to populate its `details` field, which was then displayed to the user in the UI. This leaked internal package structures, library versions, and execution flow.
+**Learning:** Even convenience methods for debugging can become security risks if they propagate sensitive internal data to user-facing components. In Android, `VpnService` and native JNI interactions can provide particularly sensitive stack traces.
+**Prevention:** Use `e.javaClass.simpleName` or a generic error code for user-facing details. Reserved full stack traces for secure, internal logging only.

--- a/app/src/main/java/com/multiregionvpn/core/VpnError.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnError.kt
@@ -83,7 +83,10 @@ data class VpnError(
     companion object {
         fun fromException(e: Throwable, tunnelId: String? = null): VpnError {
             val errorMsg = e.message ?: "Unknown error"
-            val details = e.stackTraceToString()
+            // SECURITY FIX: Do not leak the full stack trace in the 'details' field.
+            // Using the exception's simple name provides useful context for debugging
+            // without exposing internal implementation details or sensitive code structure.
+            val details = e.javaClass.simpleName
             
             return when {
                 errorMsg.contains("auth", ignoreCase = true) ||

--- a/app/src/test/java/com/multiregionvpn/core/VpnErrorSecurityTest.kt
+++ b/app/src/test/java/com/multiregionvpn/core/VpnErrorSecurityTest.kt
@@ -1,0 +1,39 @@
+package com.multiregionvpn.core
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VpnErrorSecurityTest {
+
+    @Test
+    fun `fromException should not leak full stack trace in details`() {
+        val exception = RuntimeException("Sensitive connection error")
+        val vpnError = VpnError.fromException(exception)
+
+        val details = vpnError.details ?: ""
+
+        // Before fix: details contains full stack trace with "at com.multiregionvpn..."
+        // After fix: details should only contain the exception class name or a generic message
+
+        assertFalse("VpnError details should not contain full stack trace markers",
+            details.contains("at ") && details.contains("VpnErrorSecurityTest"))
+
+        assertTrue("VpnError details should contain exception type for debugging",
+            details.contains("RuntimeException"))
+    }
+
+    @Test
+    fun `getUserMessage should provide helpful but safe information`() {
+        val vpnError = VpnError(
+            type = VpnError.ErrorType.AUTHENTICATION_FAILED,
+            message = "auth failed",
+            details = "RuntimeException"
+        )
+
+        val userMessage = vpnError.getUserMessage()
+
+        assertTrue("User message should contain the details", userMessage.contains("RuntimeException"))
+        assertFalse("User message should not contain internal stack traces", userMessage.contains("at com.multiregionvpn"))
+    }
+}


### PR DESCRIPTION
This change addresses a security vulnerability where internal stack traces were exposed to users through the `VpnError` class.

**🚨 Severity:** MEDIUM
**💡 Vulnerability:** Information Exposure through Error Messages
**🎯 Impact:** Leakage of internal package structures, library versions, and execution flow details to the UI, which could be used to facilitate further attacks.
**🔧 Fix:** Modified `VpnError.fromException()` to use the exception's class simple name instead of the full stack trace.
**✅ Verification:** Added `VpnErrorSecurityTest.kt` to assert that the `details` field no longer contains stack trace markers. Verified via code inspection due to Java/AGP version conflict in the sandbox.

---
*PR created automatically by Jules for task [11103060937780573399](https://jules.google.com/task/11103060937780573399) started by @thepont*