### PR TITLE
🛡️ Sentinel: [HIGH] Secure GeoIP lookup with HTTPS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal
+
+## 2025-05-15 - Insecure GeoIP Lookup Fixed
+**Vulnerability:** GeoIpService.kt used an insecure HTTP endpoint (`http://ip-api.com/`) for geographic region lookups, transmitting the user's IP address and location in plaintext. The `network_security_config.xml` also explicitly allowed cleartext traffic for this domain.
+**Learning:** Transitioning to `https://ipwho.is/` provides a free HTTPS-capable replacement. This required updating data mapping (Snake_case `country_code` to CamelCase `countryCode`) using `@SerializedName` in Gson and `@Json` in Moshi to maintain codebase consistency while fixing the transport security.
+**Prevention:** Always use HTTPS for external services, especially those involving user identifiers like IP addresses. Periodically audit `network_security_config.xml` for `cleartextTrafficPermitted="true"` exceptions.

--- a/app/src/androidTest/java/com/multiregionvpn/IpCheckService.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/IpCheckService.kt
@@ -9,12 +9,12 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.GET
 
 /**
- * Data class for the ip-api.com response
+ * Data class for the ipwho.is response
  */
 @JsonClass(generateAdapter = true)
 data class IpInfo(
-    @Json(name = "countryCode") val countryCode: String?,
-    @Json(name = "query") val ipAddress: String?,
+    @Json(name = "country_code") val countryCode: String?,
+    @Json(name = "ip") val ipAddress: String?,
     @Json(name = "country") val country: String?,
     @Json(name = "city") val city: String?
 ) {
@@ -29,7 +29,7 @@ data class IpInfo(
  * Retrofit interface for IP geolocation checking
  */
 interface IpApiService {
-    @GET("/json")
+    @GET("/")
     suspend fun getIpInfo(): IpInfo
 }
 
@@ -41,10 +41,9 @@ object IpCheckService {
         .add(KotlinJsonAdapterFactory())
         .build()
 
-    // Use ip-api.com with HTTP (requires cleartext traffic enabled)
-    // The test manifest has android:usesCleartextTraffic="true"
+    // Use ipwho.is with HTTPS (more secure)
     private val retrofit = Retrofit.Builder()
-        .baseUrl("http://ip-api.com/")
+        .baseUrl("https://ipwho.is/")
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .build()
 

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -1,6 +1,7 @@
 package com.multiregionvpn.network
 
 import android.util.Log
+import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.Retrofit
@@ -8,22 +9,23 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 
 data class GeoIpResponse(
+    @SerializedName("country_code")
     val countryCode: String?,
     val country: String?,
     val region: String?
 )
 
 interface GeoIpApi {
-    @GET("json")
+    @GET("/")
     suspend fun getCurrentLocation(): GeoIpResponse
 }
 
 /**
- * Service to get current geographic region using ip-api.com
+ * Service to get current geographic region using ipwho.is (HTTPS)
  */
 class GeoIpService {
     private val api = Retrofit.Builder()
-        .baseUrl("http://ip-api.com/")
+        .baseUrl("https://ipwho.is/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(GeoIpApi::class.java)

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Allow cleartext traffic for testing with ip-api.com -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">ip-api.com</domain>
-    </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />


### PR DESCRIPTION
This PR addresses a security vulnerability where user location data was transmitted over insecure HTTP. By switching to ipwho.is with HTTPS and enforcing a strict network security policy (removing cleartext exceptions), we ensure that all metadata required for auto-routing is protected in transit. This follows the defense-in-depth principle and aligns with secure coding standards for mobile applications.

---
*PR created automatically by Jules for task [7409590499654349452](https://jules.google.com/task/7409590499654349452) started by @thepont*