### PR TITLE
🛡️ Sentinel: Enforce HTTPS and harden manifest

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-24 - Manifest Hardening and HTTPS Enforcement
+**Vulnerability:** GeoIP lookups were performed over HTTP and the manifest allowed ADB backups.
+**Learning:** Default Android configurations (like allowBackup) and free-tier GeoIP services (like ip-api.com) often default to insecure transport or settings.
+**Prevention:** Always explicitly disable allowBackup and cleartext traffic in the production manifest while providing overrides for debug builds.

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -17,7 +17,7 @@
     <application
         android:allowBackup="true"
         android:usesCleartextTraffic="true"
-        tools:replace="android:allowBackup,android:usesCleartextTraffic"
+        tools:replace="android:allowBackup,android:usesCleartextTraffic,android:theme,android:name,android:label"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,6 +15,9 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:allowBackup="true"
+        android:usesCleartextTraffic="true"
+        tools:replace="android:allowBackup,android:usesCleartextTraffic"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -17,7 +17,7 @@
     <application
         android:allowBackup="true"
         android:usesCleartextTraffic="true"
-        tools:replace="android:allowBackup,android:usesCleartextTraffic,android:theme,android:name,android:label"
+        tools:replace="android:allowBackup,android:usesCleartextTraffic"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,12 +20,12 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -1,6 +1,7 @@
 package com.multiregionvpn.network
 
 import android.util.Log
+import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.Retrofit
@@ -8,22 +9,23 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 
 data class GeoIpResponse(
+    @SerializedName("country_code")
     val countryCode: String?,
     val country: String?,
     val region: String?
 )
 
 interface GeoIpApi {
-    @GET("json")
+    @GET("/")
     suspend fun getCurrentLocation(): GeoIpResponse
 }
 
 /**
- * Service to get current geographic region using ip-api.com
+ * Service to get current geographic region using ipwho.is
  */
 class GeoIpService {
     private val api = Retrofit.Builder()
-        .baseUrl("http://ip-api.com/")
+        .baseUrl("https://ipwho.is/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(GeoIpApi::class.java)

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -12,6 +12,7 @@ data class GeoIpResponse(
     @SerializedName("country_code")
     val countryCode: String?,
     val country: String?,
+    @SerializedName("region_code")
     val region: String?
 )
 

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Allow cleartext traffic for testing with ip-api.com -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">ip-api.com</domain>
-    </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
     </base-config>
 </network-security-config>
-
-


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unencrypted GeoIP lookups and insecure manifest defaults.
🎯 Impact: GeoIP lookups could be intercepted or manipulated; ADB backups could leak local app data.
🔧 Fix: Switched to an HTTPS-supporting GeoIP provider and hardened manifest settings with debug-only overrides.
✅ Verification: Verified manifest and source code changes manually. Unit tests were attempted but blocked by a known environmental issue with 'jlink'.

---
*PR created automatically by Jules for task [10687543484377392685](https://jules.google.com/task/10687543484377392685) started by @thepont*