### PR TITLE
🛡️ Sentinel: [HIGH] Harden network security and production manifest

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Production Manifest Hardening with Debug Overrides
+**Vulnerability:** Cleartext traffic allowed by default and sensitive data exposed via ADB backup.
+**Learning:** Hardening the production manifest (`android:allowBackup="false"`, `android:usesCleartextTraffic="false"`) can break debug tools and local E2E tests that rely on unencrypted traffic (e.g., local mock servers).
+**Prevention:** Use the debug source set (`app/src/debug/AndroidManifest.xml`) to explicitly override production security constraints using `tools:replace="android:allowBackup,android:usesCleartextTraffic"`. This maintains a high security posture for users while preserving developer velocity and testability.

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,6 +15,9 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:name=".MainApplication"
+        android:label="@string/app_name"
+        android:theme="@style/Theme.MultiRegionVPN"
         android:allowBackup="true"
         android:usesCleartextTraffic="true"
         tools:ignore="MissingLeanbackLauncher"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:allowBackup="true"
         android:usesCleartextTraffic="true"
         tools:ignore="MissingLeanbackLauncher"
-        tools:replace="android:allowBackup,android:usesCleartextTraffic">
+        tools:replace="android:allowBackup,android:usesCleartextTraffic,android:theme,android:name,android:label">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"
             android:exported="true"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,13 +15,10 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
-        android:name=".MainApplication"
-        android:label="@string/app_name"
-        android:theme="@style/Theme.MultiRegionVPN"
         android:allowBackup="true"
         android:usesCleartextTraffic="true"
         tools:ignore="MissingLeanbackLauncher"
-        tools:replace="android:allowBackup,android:usesCleartextTraffic,android:theme,android:name,android:label">
+        tools:replace="android:allowBackup,android:usesCleartextTraffic">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"
             android:exported="true"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,7 +15,10 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
-        tools:ignore="MissingLeanbackLauncher">
+        android:allowBackup="true"
+        android:usesCleartextTraffic="true"
+        tools:ignore="MissingLeanbackLauncher"
+        tools:replace="android:allowBackup,android:usesCleartextTraffic">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"
             android:exported="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,12 +20,12 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/java/com/multiregionvpn/core/VpnError.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnError.kt
@@ -83,7 +83,8 @@ data class VpnError(
     companion object {
         fun fromException(e: Throwable, tunnelId: String? = null): VpnError {
             val errorMsg = e.message ?: "Unknown error"
-            val details = e.stackTraceToString()
+            // Sanitize details to prevent leaking internal stack traces (CWE-209)
+            val details = e.message ?: e.toString()
             
             return when {
                 errorMsg.contains("auth", ignoreCase = true) ||

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -1,6 +1,7 @@
 package com.multiregionvpn.network
 
 import android.util.Log
+import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.Retrofit
@@ -8,22 +9,23 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 
 data class GeoIpResponse(
+    @SerializedName("country_code")
     val countryCode: String?,
     val country: String?,
     val region: String?
 )
 
 interface GeoIpApi {
-    @GET("json")
+    @GET("/")
     suspend fun getCurrentLocation(): GeoIpResponse
 }
 
 /**
- * Service to get current geographic region using ip-api.com
+ * Service to get current geographic region using ipwho.is (HTTPS)
  */
 class GeoIpService {
     private val api = Retrofit.Builder()
-        .baseUrl("http://ip-api.com/")
+        .baseUrl("https://ipwho.is/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(GeoIpApi::class.java)

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Allow cleartext traffic for testing with ip-api.com -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">ip-api.com</domain>
-    </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
     </base-config>
 </network-security-config>
-
-

--- a/app/src/test/java/com/multiregionvpn/core/VpnErrorTest.kt
+++ b/app/src/test/java/com/multiregionvpn/core/VpnErrorTest.kt
@@ -1,0 +1,21 @@
+package com.multiregionvpn.core
+
+import org.junit.Test
+import org.junit.Assert.*
+
+class VpnErrorTest {
+    @Test
+    fun `fromException should not include stack trace in details`() {
+        val exception = RuntimeException("Sensitive error details")
+        val vpnError = VpnError.fromException(exception)
+
+        // The details should not be the full stack trace
+        val stackTraceIndicator = "at com.multiregionvpn"
+        assertFalse("Error details should not contain stack trace",
+            vpnError.details?.contains(stackTraceIndicator) ?: false)
+
+        // It should still contain the message
+        assertTrue("Error details should contain the message",
+            vpnError.details?.contains("Sensitive error details") ?: false)
+    }
+}


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability:
1. Insecure network communication: GeoIP lookups were performed over unencrypted HTTP (ip-api.com).
2. Overly permissive production manifest: `android:usesCleartextTraffic` was enabled and `android:allowBackup` was set to true in production.

🎯 Impact:
1. HTTP traffic can be intercepted or modified by an attacker (MitM), potentially leaking user location or spoofing it.
2. Cleartext traffic allows insecure communication for the entire app. Backups enable extraction of potentially sensitive app data via ADB.

🔧 Fix:
1. Migrated `GeoIpService` to use `https://ipwho.is/` (HTTPS).
2. Hardened `app/src/main/AndroidManifest.xml` by disabling cleartext traffic and backups.
3. Updated `network_security_config.xml` to enforce HTTPS.
4. Added debug manifest overrides to maintain test compatibility.

✅ Verification:
1. Verified file contents for all modified files.
2. Verified that `GeoIpService` correctly maps the new API response using `@SerializedName`.
3. Verified manifest merging logic in debug builds.

---
*PR created automatically by Jules for task [5578956936321121780](https://jules.google.com/task/5578956936321121780) started by @thepont*