### PR TITLE
🛡️ Sentinel: Harden network security by migrating to HTTPS GeoIP and disabling cleartext traffic

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Insecure GeoIP Lookup and Cleartext Traffic Exposure]
+**Vulnerability:** The application was performing GeoIP lookups over insecure HTTP (ip-api.com) and had `android:usesCleartextTraffic="true"` enabled in the production manifest.
+**Learning:** Legacy configurations often leave "temporary" cleartext exceptions for testing that persist into production, undermining the security of sensitive user data like location.
+**Prevention:** Enforce HTTPS-only traffic globally in the main manifest and use secure, TLS-enabled geolocation providers. Ensure any debug-specific cleartext exceptions are strictly isolated to the debug manifest.

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,7 +15,7 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
-        android:name=".MainApplication"
+        android:name="com.multiregionvpn.MainApplication"
         android:theme="@style/Theme.MultiRegionVPN"
         android:label="@string/app_name"
         android:allowBackup="true"
@@ -24,7 +24,7 @@
         tools:replace="android:name,android:theme,android:label,android:allowBackup,android:usesCleartextTraffic,android:networkSecurityConfig"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
-            android:name=".deviceowner.TestDeviceOwnerReceiver"
+            android:name="com.multiregionvpn.deviceowner.TestDeviceOwnerReceiver"
             android:exported="true"
             android:permission="android.permission.BIND_DEVICE_ADMIN"
             tools:ignore="DeviceAdmin">

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,6 +15,13 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:name=".MainApplication"
+        android:theme="@style/Theme.MultiRegionVPN"
+        android:label="@string/app_name"
+        android:allowBackup="true"
+        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
+        tools:replace="android:name,android:theme,android:label,android:allowBackup,android:usesCleartextTraffic,android:networkSecurityConfig"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow cleartext traffic for E2E tests (local mock servers) -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,6 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -1,6 +1,7 @@
 package com.multiregionvpn.network
 
 import android.util.Log
+import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.Retrofit
@@ -8,22 +9,23 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 
 data class GeoIpResponse(
+    @SerializedName("country_code")
     val countryCode: String?,
     val country: String?,
     val region: String?
 )
 
 interface GeoIpApi {
-    @GET("json")
+    @GET("/")
     suspend fun getCurrentLocation(): GeoIpResponse
 }
 
 /**
- * Service to get current geographic region using ip-api.com
+ * Service to get current geographic region using ipwho.is (HTTPS)
  */
 class GeoIpService {
     private val api = Retrofit.Builder()
-        .baseUrl("http://ip-api.com/")
+        .baseUrl("https://ipwho.is/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(GeoIpApi::class.java)

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -12,6 +12,7 @@ data class GeoIpResponse(
     @SerializedName("country_code")
     val countryCode: String?,
     val country: String?,
+    @SerializedName("region_code")
     val region: String?
 )
 

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Allow cleartext traffic for testing with ip-api.com -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">ip-api.com</domain>
-    </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
     </base-config>
 </network-security-config>
-
-


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Insecure network transmission of location data and global cleartext traffic permitted.
🎯 Impact: User location data could be intercepted or modified via MITM attacks. Global cleartext permission increases the attack surface for all network operations.
🔧 Fix:
- Migrated GeoIP lookup to `ipwho.is` via HTTPS.
- Disabled cleartext traffic in the main Manifest.
- Removed domain-specific cleartext exemptions in the network security config.
✅ Verification:
- Manual verification of source code and configuration files.
- Verified that `ipwho.is` returns the expected JSON structure over HTTPS.
- Attempted to run unit tests (partially blocked by environment-specific jlink issue, but unrelated to these changes).

---
*PR created automatically by Jules for task [12297246226464928229](https://jules.google.com/task/12297246226464928229) started by @thepont*