### PR TITLE
🛡️ Sentinel: Migrate GeoIpService to HTTPS and harden network security

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Secure GeoIP Migration and HTTPS Enforcement
+**Vulnerability:** Insecure geographic region lookup via HTTP (ip-api.com) and permissive network security configuration allowing cleartext traffic for that domain.
+**Learning:** free tier of ip-api.com explicitly blocks HTTPS requests (403 Forbidden). Migrating to freeipapi.com provides a compatible free tier that supports HTTPS.
+**Prevention:** Always enforce HTTPS in network_security_config.xml and use @SerializedName for API migrations to maintain backward compatibility with existing data models.

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -2,15 +2,27 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingLeanbackLauncher">
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+    <uses-feature
+        android:name="android.software.leanback"
+        android:required="false" />
+
 
     <uses-permission
         android:name="android.permission.MANAGE_CA_CERTIFICATES"
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:name=".MainApplication"
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
         android:usesCleartextTraffic="true"
-        tools:replace="android:networkSecurityConfig,android:usesCleartextTraffic">
+        tools:ignore="MissingLeanbackLauncher"
+        tools:replace="android:name,android:theme,android:label,android:allowBackup,android:usesCleartextTraffic,android:networkSecurityConfig">
 
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -2,20 +2,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingLeanbackLauncher">
-    <uses-feature
-        android:name="android.hardware.touchscreen"
-        android:required="false" />
-    <uses-feature
-        android:name="android.software.leanback"
-        android:required="false" />
-
 
     <uses-permission
         android:name="android.permission.MANAGE_CA_CERTIFICATES"
         tools:ignore="ProtectedPermissions" />
 
     <application
-        tools:ignore="MissingLeanbackLauncher">
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:usesCleartextTraffic="true"
+        tools:replace="android:networkSecurityConfig,android:usesCleartextTraffic">
+
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"
             android:exported="true"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,14 +15,10 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
-        android:name=".MainApplication"
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
         android:usesCleartextTraffic="true"
         tools:ignore="MissingLeanbackLauncher"
-        tools:replace="android:name,android:theme,android:label,android:allowBackup,android:usesCleartextTraffic,android:networkSecurityConfig">
+        tools:replace="android:networkSecurityConfig,android:usesCleartextTraffic">
 
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow cleartext traffic for local E2E tests -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
         android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
-        tools:replace="android:theme,android:name,android:label">
+        tools:replace="android:theme,android:label">
         
         <!-- Mobile Activity -->
         <activity

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -1,6 +1,7 @@
 package com.multiregionvpn.network
 
 import android.util.Log
+import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.Retrofit
@@ -9,7 +10,9 @@ import retrofit2.http.GET
 
 data class GeoIpResponse(
     val countryCode: String?,
+    @SerializedName("countryName")
     val country: String?,
+    @SerializedName("regionName")
     val region: String?
 )
 
@@ -19,11 +22,11 @@ interface GeoIpApi {
 }
 
 /**
- * Service to get current geographic region using ip-api.com
+ * Service to get current geographic region using freeipapi.com (HTTPS)
  */
 class GeoIpService {
     private val api = Retrofit.Builder()
-        .baseUrl("http://ip-api.com/")
+        .baseUrl("https://free.freeipapi.com/api/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(GeoIpApi::class.java)

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -26,7 +26,7 @@ interface GeoIpApi {
  */
 class GeoIpService {
     private val api = Retrofit.Builder()
-        .baseUrl("https://free.freeipapi.com/api/")
+        .baseUrl("https://freeipapi.com/api/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(GeoIpApi::class.java)

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -26,7 +26,7 @@ interface GeoIpApi {
  */
 class GeoIpService {
     private val api = Retrofit.Builder()
-        .baseUrl("https://freeipapi.com/api/")
+        .baseUrl("https://free.freeipapi.com/api/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(GeoIpApi::class.java)

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Allow cleartext traffic for testing with ip-api.com -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">ip-api.com</domain>
-    </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
     </base-config>
 </network-security-config>
-
-


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Geographic region lookup was performed over insecure HTTP (ip-api.com), and the app had a permissive network security configuration allowing cleartext traffic.
🎯 Impact: User's location and IP could be intercepted or spoofed via Man-in-the-Middle (MitM) attacks.
🔧 Fix:
- Migrated `GeoIpService` to `freeipapi.com` which supports HTTPS on its free tier.
- Hardened `app/src/main/res/xml/network_security_config.xml` by removing the cleartext exception for `ip-api.com`, enforcing HTTPS globally.
- Used `@SerializedName` in `GeoIpResponse` to ensure zero-breakage migration of existing code.
✅ Verification:
- Manually verified code logic and compatibility.
- Verified `network_security_config.xml` disables cleartext traffic.
- Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13094830940130962195](https://jules.google.com/task/13094830940130962195) started by @thepont*