### PR TITLE
🛡️ Sentinel: Harden security - Fix info leakage and enforce HTTPS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
 ## 2026-06-25 - Manifest Merger Conflict during Hardening
 **Vulnerability:** Manifest merger failure or Hilt initialization failure after disabling cleartext traffic.
 **Learning:** In this project, the main manifest uses `tools:replace` for `android:name`, `android:theme`, and `android:label`. When overriding security settings in a debug manifest (e.g., to allow cleartext for tests), these attributes must be explicitly redefined in the debug manifest and included in its own `tools:replace` list. Failure to do so causes manifest merger errors that prevent the application from starting.
-**Prevention:** Always include all attributes from the main manifest's `tools:replace` list in the debug manifest when redefining the `<application>` tag.
+**Prevention:** Always include all attributes from the main manifest's `tools:replace` list in the debug manifest when redefining the `<application>` tag. Additionally, use fully qualified class names for `android:name` in the debug manifest to ensure proper Hilt/Application initialization.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-25 - Manifest Merger Conflict during Hardening
+**Vulnerability:** Manifest merger failure or Hilt initialization failure after disabling cleartext traffic.
+**Learning:** In this project, the main manifest uses `tools:replace` for `android:name`, `android:theme`, and `android:label`. When overriding security settings in a debug manifest (e.g., to allow cleartext for tests), these attributes must be explicitly redefined in the debug manifest and included in its own `tools:replace` list. Failure to do so causes manifest merger errors that prevent the application from starting.
+**Prevention:** Always include all attributes from the main manifest's `tools:replace` list in the debug manifest when redefining the `<application>` tag.

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,7 +15,14 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
-        tools:ignore="MissingLeanbackLauncher">
+        android:name=".MainApplication"
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:theme="@style/Theme.MultiRegionVPN"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:usesCleartextTraffic="true"
+        tools:ignore="MissingLeanbackLauncher"
+        tools:replace="android:allowBackup,android:usesCleartextTraffic,android:networkSecurityConfig,android:name,android:theme,android:label">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"
             android:exported="true"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,7 +15,7 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
-        android:name=".MainApplication"
+        android:name="com.multiregionvpn.MainApplication"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:theme="@style/Theme.MultiRegionVPN"

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <!-- Allow cleartext traffic for E2E tests with local mock servers -->
-    <base-config cleartextTrafficPermitted="true">
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">ip-api.com</domain>
+    </domain-config>
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow cleartext traffic for E2E tests with local mock servers -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/java/com/multiregionvpn/core/VpnError.kt
+++ b/app/src/main/java/com/multiregionvpn/core/VpnError.kt
@@ -44,38 +44,38 @@ data class VpnError(
                 "• Go to https://my.nordaccount.com/dashboard/nordvpn/manual-setup/\n" +
                 "• Generate new Service Credentials\n" +
                 "• Update them in the app settings\n\n" +
-                "Error: ${details ?: message}"
+                "Error: $message"
             }
             ErrorType.CONNECTION_FAILED -> {
                 "Could not connect to VPN server:\n\n" +
                 "• Check your internet connection\n" +
                 "• The VPN server may be temporarily unavailable\n" +
                 "• Try a different server region\n\n" +
-                "Error: ${details ?: message}"
+                "Error: $message"
             }
             ErrorType.CONFIG_ERROR -> {
                 "Invalid VPN configuration:\n\n" +
                 "• The server configuration may be outdated\n" +
                 "• Try removing and re-adding the VPN server\n" +
                 "• Check if the server hostname is correct\n\n" +
-                "Error: ${details ?: message}"
+                "Error: $message"
             }
             ErrorType.INTERFACE_ERROR -> {
                 "VPN interface error:\n\n" +
                 "• VPN permission may not be granted\n" +
                 "• Another VPN may be active\n" +
                 "• Try restarting the app\n\n" +
-                "Error: ${details ?: message}"
+                "Error: $message"
             }
             ErrorType.TUNNEL_ERROR -> {
                 "Tunnel creation failed:\n\n" +
                 "• Check your VPN credentials\n" +
                 "• Verify the server is reachable\n" +
                 "• Try a different server\n\n" +
-                "Error: ${details ?: message}"
+                "Error: $message"
             }
             ErrorType.UNKNOWN -> {
-                "An unexpected error occurred:\n\n${details ?: message}"
+                "An unexpected error occurred:\n\n$message"
             }
         }
     }

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -5,12 +5,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import com.google.gson.annotations.SerializedName
 import retrofit2.http.GET
 
 data class GeoIpResponse(
     val countryCode: String?,
-    val country: String?,
-    val region: String?
+    @SerializedName("countryName") val country: String?,
+    @SerializedName("regionName") val region: String?
 )
 
 interface GeoIpApi {
@@ -19,11 +20,11 @@ interface GeoIpApi {
 }
 
 /**
- * Service to get current geographic region using ip-api.com
+ * Service to get current geographic region using freeipapi.com
  */
 class GeoIpService {
     private val api = Retrofit.Builder()
-        .baseUrl("http://ip-api.com/")
+        .baseUrl("https://free.freeipapi.com/api/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(GeoIpApi::class.java)

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Allow cleartext traffic for testing with ip-api.com -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">ip-api.com</domain>
-    </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
     </base-config>
 </network-security-config>
-
-

--- a/app/src/test/java/com/multiregionvpn/core/VpnErrorTest.kt
+++ b/app/src/test/java/com/multiregionvpn/core/VpnErrorTest.kt
@@ -1,0 +1,43 @@
+package com.multiregionvpn.core
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VpnErrorTest {
+
+    @Test
+    fun `getUserMessage should not contain stack trace when created from exception`() {
+        // Arrange
+        val exceptionMessage = "Test exception message"
+        val exception = RuntimeException(exceptionMessage)
+        val vpnError = VpnError.fromException(exception)
+
+        // Act
+        val userMessage = vpnError.getUserMessage()
+
+        // Assert
+        assertTrue("User message should contain the original error message", userMessage.contains(exceptionMessage))
+        assertFalse("User message should NOT contain stack trace information", userMessage.contains("RuntimeException"))
+        assertFalse("User message should NOT contain stack trace information (at ...)", userMessage.contains("at "))
+
+        // Verify details still contains the stack trace (for logging/debugging)
+        assertTrue("Details should still contain the stack trace for internal logging", vpnError.details?.contains("RuntimeException") == true)
+    }
+
+    @Test
+    fun `getUserMessage should work for all error types without leaking details`() {
+        VpnError.ErrorType.values().forEach { type ->
+            val vpnError = VpnError(
+                type = type,
+                message = "Plain message",
+                details = "Secret stack trace at com.example.Leak"
+            )
+
+            val userMessage = vpnError.getUserMessage()
+
+            assertFalse("User message for $type should not contain details", userMessage.contains("Secret stack trace"))
+            assertTrue("User message for $type should contain the message", userMessage.contains("Plain message"))
+        }
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Harden security: Fix info leakage and enforce HTTPS

### 🚨 Severity: HIGH

### 💡 Vulnerability
1. **Information Leakage (CWE-209):** `VpnError.kt` was exposing internal stack traces to the user via the `getUserMessage()` function.
2. **Insecure Data Transmission:** `GeoIpService.kt` was using unencrypted HTTP to fetch geographic information, and cleartext traffic was permitted globally in the application manifest.

### 🎯 Impact
- Attackers or curious users could gain insights into the application's internal structure and dependencies through stack traces.
- Geographic data and IP addresses were vulnerable to interception via man-in-the-middle (MITM) attacks during GeoIP lookups.

### 🔧 Fix
- Modified `VpnError.kt` to exclude the `details` field from user-facing messages.
- Migrated `GeoIpService.kt` to use `https://free.freeipapi.com/api/` with proper field mapping via `@SerializedName`.
- Set `android:usesCleartextTraffic="false"` in `AndroidManifest.xml` and removed cleartext exceptions from `network_security_config.xml`.

### ✅ Verification
- Verified code correctness via Kotlin compilation (`./gradlew :app:compileDebugKotlin`).
- Added `VpnErrorTest.kt` unit test to ensure stack traces are suppressed in user-facing messages.
- Manually inspected the hardened network security configurations.

---
*PR created automatically by Jules for task [7993104903386233054](https://jules.google.com/task/7993104903386233054) started by @thepont*