### PR TITLE
🛡️ Sentinel: [HIGH] Fix Insecure GeoIP Transmission

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-07 - [Insecure GeoIP Transmission]
+**Vulnerability:** The application was using `http://ip-api.com` for geolocation lookups, which transmits the user's IP and potential location data in cleartext. This allows for MitM interception and spoofing of routing decisions.
+**Learning:** The free tier of `ip-api.com` does not support HTTPS (returns 403 Forbidden). Developers often stick to insecure endpoints when the familiar provider lacks free SSL.
+**Prevention:** Always prioritize HTTPS-capable API providers (like `freeipapi.com`) and enforce `android:usesCleartextTraffic="false"` in the production manifest to catch these issues during development.

--- a/.maestro/07_verify_routing_with_chrome.yaml
+++ b/.maestro/07_verify_routing_with_chrome.yaml
@@ -35,7 +35,7 @@ appId: "com.multiregionvpn"
 - tapOn:
     id: "url_bar"
     optional: true
-- inputText: "https://free.freeipapi.com/api/json"
+- inputText: "https://freeipapi.com/api/json"
 - pressKey: Enter
 
 # Wait for page to load (use a simple assertion with optional)

--- a/.maestro/07_verify_routing_with_chrome.yaml
+++ b/.maestro/07_verify_routing_with_chrome.yaml
@@ -40,7 +40,7 @@ appId: "com.multiregionvpn"
 
 # Wait for page to load (use a simple assertion with optional)
 - assertVisible:
-    text: ".*freeipapi.*|United Kingdom|GB|country|city"
+    text: ".*freeipapi.*|United Kingdom|GB|countryName|cityName"
     optional: true
 
 # Look for "GB" in the page content (UK country code)

--- a/.maestro/07_verify_routing_with_chrome.yaml
+++ b/.maestro/07_verify_routing_with_chrome.yaml
@@ -35,12 +35,12 @@ appId: "com.multiregionvpn"
 - tapOn:
     id: "url_bar"
     optional: true
-- inputText: "ip-api.com/json"
+- inputText: "https://freeipapi.com/api/json"
 - pressKey: Enter
 
 # Wait for page to load (use a simple assertion with optional)
 - assertVisible:
-    text: ".*ip-api.*|United Kingdom|GB|country|city"
+    text: ".*freeipapi.*|United Kingdom|GB|country|city"
     optional: true
 
 # Look for "GB" in the page content (UK country code)
@@ -68,4 +68,3 @@ appId: "com.multiregionvpn"
 - waitForAnimationToEnd
 - assertVisible:
     text: "Disconnected|Error|Direct Internet"
-

--- a/.maestro/07_verify_routing_with_chrome.yaml
+++ b/.maestro/07_verify_routing_with_chrome.yaml
@@ -35,7 +35,7 @@ appId: "com.multiregionvpn"
 - tapOn:
     id: "url_bar"
     optional: true
-- inputText: "https://freeipapi.com/api/json"
+- inputText: "https://free.freeipapi.com/api/json"
 - pressKey: Enter
 
 # Wait for page to load (use a simple assertion with optional)

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -155,7 +155,7 @@ maestro test .maestro/07_verify_routing_with_chrome.yaml
 - Assign Chrome to UK tunnel
 - Start VPN
 - Launch Chrome
-- Navigate to ip-api.com
+- Navigate to https://freeipapi.com/api/json
 - Verify UK IP (manual verification)
 
 **Duration:** ~45 seconds

--- a/app/src/androidTest/java/com/multiregionvpn/DiagnosticRoutingTest.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/DiagnosticRoutingTest.kt
@@ -163,11 +163,11 @@ class DiagnosticRoutingTest {
         
         // Step 6: Make simple HTTP request
         println("\n6️⃣ Making HTTP request...")
-        println("   URL: https://freeipapi.com/api/json")
+        println("   URL: https://free.freeipapi.com/api/json")
         println("   Expected: This request should go through VPN → UK servers")
         println("   Method: Direct HttpURLConnection (no Retrofit)")
         
-        val url = URL("https://freeipapi.com/api/json")
+        val url = URL("https://free.freeipapi.com/api/json")
         val connection = url.openConnection() as HttpURLConnection
         connection.connectTimeout = 10000
         connection.readTimeout = 10000

--- a/app/src/androidTest/java/com/multiregionvpn/DiagnosticRoutingTest.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/DiagnosticRoutingTest.kt
@@ -163,11 +163,11 @@ class DiagnosticRoutingTest {
         
         // Step 6: Make simple HTTP request
         println("\n6️⃣ Making HTTP request...")
-        println("   URL: https://free.freeipapi.com/api/json")
+        println("   URL: https://freeipapi.com/api/json")
         println("   Expected: This request should go through VPN → UK servers")
         println("   Method: Direct HttpURLConnection (no Retrofit)")
         
-        val url = URL("https://free.freeipapi.com/api/json")
+        val url = URL("https://freeipapi.com/api/json")
         val connection = url.openConnection() as HttpURLConnection
         connection.connectTimeout = 10000
         connection.readTimeout = 10000

--- a/app/src/androidTest/java/com/multiregionvpn/DiagnosticRoutingTest.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/DiagnosticRoutingTest.kt
@@ -163,11 +163,11 @@ class DiagnosticRoutingTest {
         
         // Step 6: Make simple HTTP request
         println("\n6️⃣ Making HTTP request...")
-        println("   URL: http://ip-api.com/json")
+        println("   URL: https://freeipapi.com/api/json")
         println("   Expected: This request should go through VPN → UK servers")
         println("   Method: Direct HttpURLConnection (no Retrofit)")
         
-        val url = URL("http://ip-api.com/json")
+        val url = URL("https://freeipapi.com/api/json")
         val connection = url.openConnection() as HttpURLConnection
         connection.connectTimeout = 10000
         connection.readTimeout = 10000
@@ -202,4 +202,3 @@ class DiagnosticRoutingTest {
         }
     }
 }
-

--- a/app/src/androidTest/java/com/multiregionvpn/IpCheckService.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/IpCheckService.kt
@@ -42,7 +42,7 @@ object IpCheckService {
         .build()
 
     // Use freeipapi.com with HTTPS for secure testing
-    // Using free.freeipapi.com subdomain for direct, redirect-free access.
+    // Using free.freeipapi.com subdomain for direct redirect-free access
     private val retrofit = Retrofit.Builder()
         .baseUrl("https://free.freeipapi.com/api/")
         .addConverterFactory(MoshiConverterFactory.create(moshi))

--- a/app/src/androidTest/java/com/multiregionvpn/IpCheckService.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/IpCheckService.kt
@@ -42,9 +42,8 @@ object IpCheckService {
         .build()
 
     // Use freeipapi.com with HTTPS for secure testing
-    // Using free.freeipapi.com subdomain for direct redirect-free access
     private val retrofit = Retrofit.Builder()
-        .baseUrl("https://free.freeipapi.com/api/")
+        .baseUrl("https://freeipapi.com/api/")
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .build()
 

--- a/app/src/androidTest/java/com/multiregionvpn/IpCheckService.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/IpCheckService.kt
@@ -9,14 +9,14 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.GET
 
 /**
- * Data class for the ip-api.com response
+ * Data class for the freeipapi.com response
  */
 @JsonClass(generateAdapter = true)
 data class IpInfo(
     @Json(name = "countryCode") val countryCode: String?,
-    @Json(name = "query") val ipAddress: String?,
-    @Json(name = "country") val country: String?,
-    @Json(name = "city") val city: String?
+    @Json(name = "ipAddress") val ipAddress: String?,
+    @Json(name = "countryName") val country: String?,
+    @Json(name = "cityName") val city: String?
 ) {
     val normalizedCountryCode: String?
         get() = countryCode
@@ -29,7 +29,7 @@ data class IpInfo(
  * Retrofit interface for IP geolocation checking
  */
 interface IpApiService {
-    @GET("/json")
+    @GET("json")
     suspend fun getIpInfo(): IpInfo
 }
 
@@ -41,13 +41,11 @@ object IpCheckService {
         .add(KotlinJsonAdapterFactory())
         .build()
 
-    // Use ip-api.com with HTTP (requires cleartext traffic enabled)
-    // The test manifest has android:usesCleartextTraffic="true"
+    // Use freeipapi.com with HTTPS for secure testing
     private val retrofit = Retrofit.Builder()
-        .baseUrl("http://ip-api.com/")
+        .baseUrl("https://freeipapi.com/api/")
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .build()
 
     val api: IpApiService = retrofit.create(IpApiService::class.java)
 }
-

--- a/app/src/androidTest/java/com/multiregionvpn/IpCheckService.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/IpCheckService.kt
@@ -42,8 +42,9 @@ object IpCheckService {
         .build()
 
     // Use freeipapi.com with HTTPS for secure testing
+    // Using free.freeipapi.com subdomain for direct, redirect-free access.
     private val retrofit = Retrofit.Builder()
-        .baseUrl("https://freeipapi.com/api/")
+        .baseUrl("https://free.freeipapi.com/api/")
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .build()
 

--- a/app/src/androidTest/java/com/multiregionvpn/ProductionAppRoutingTest.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/ProductionAppRoutingTest.kt
@@ -184,7 +184,7 @@ class ProductionAppRoutingTest {
         println("\n5️⃣ MANUAL VERIFICATION REQUIRED:")
         println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
         println("1. Open Chrome on your device")
-        println("2. Navigate to: http://ip-api.com/json")
+        println("2. Navigate to: https://freeipapi.com/api/json")
         println("3. Check the 'countryCode' field")
         println("   ✅ Expected: \"GB\" (United Kingdom)")
         println("   ❌ If you see your local country, routing failed")
@@ -251,7 +251,7 @@ class ProductionAppRoutingTest {
         
         println("\n📊 VPN IS ACTIVE - Chrome should be in allowed apps")
         println("   To verify: Check logcat for 'ALLOWED: $CHROME_PACKAGE'")
-        println("   To test: Open Chrome and browse to http://ip-api.com/json")
+        println("   To test: Open Chrome and browse to https://freeipapi.com/api/json")
         println("   Expected: Packets from UID $chromeUid should appear in PacketRouter logs")
         println()
         println("Test will keep VPN active for 60 seconds for observation...")
@@ -260,4 +260,3 @@ class ProductionAppRoutingTest {
         println("✅ Observation period complete")
     }
 }
-

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -2,13 +2,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingLeanbackLauncher">
+
+    <!-- Features and permissions for debug environment -->
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />
     <uses-feature
         android:name="android.software.leanback"
         android:required="false" />
-
 
     <uses-permission
         android:name="android.permission.MANAGE_CA_CERTIFICATES"
@@ -20,6 +21,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         tools:ignore="MissingLeanbackLauncher"
         tools:replace="android:usesCleartextTraffic,android:allowBackup,android:networkSecurityConfig">
+
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"
             android:exported="true"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -2,6 +2,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingLeanbackLauncher">
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+    <uses-feature
+        android:name="android.software.leanback"
+        android:required="false" />
+
+
+    <uses-permission
+        android:name="android.permission.MANAGE_CA_CERTIFICATES"
+        tools:ignore="ProtectedPermissions" />
 
     <application
         android:usesCleartextTraffic="true"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,7 +15,10 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
-        tools:ignore="MissingLeanbackLauncher">
+        android:usesCleartextTraffic="true"
+        android:allowBackup="true"
+        tools:ignore="MissingLeanbackLauncher"
+        tools:replace="android:usesCleartextTraffic,android:allowBackup">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"
             android:exported="true"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -2,23 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingLeanbackLauncher">
-    <uses-feature
-        android:name="android.hardware.touchscreen"
-        android:required="false" />
-    <uses-feature
-        android:name="android.software.leanback"
-        android:required="false" />
-
-
-    <uses-permission
-        android:name="android.permission.MANAGE_CA_CERTIFICATES"
-        tools:ignore="ProtectedPermissions" />
 
     <application
         android:usesCleartextTraffic="true"
         android:allowBackup="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:ignore="MissingLeanbackLauncher"
-        tools:replace="android:usesCleartextTraffic,android:allowBackup">
+        tools:replace="android:usesCleartextTraffic,android:allowBackup,android:networkSecurityConfig">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"
             android:exported="true"

--- a/app/src/debug/java/com/multiregionvpn/deviceowner/TestDeviceOwnerReceiver.kt
+++ b/app/src/debug/java/com/multiregionvpn/deviceowner/TestDeviceOwnerReceiver.kt
@@ -1,0 +1,15 @@
+package com.multiregionvpn.deviceowner
+
+import android.app.admin.DeviceAdminReceiver
+import android.content.Context
+import android.content.Intent
+
+/**
+ * Placeholder DeviceAdminReceiver for E2E tests.
+ * This is used by automated tests to perform privileged actions in the emulator.
+ */
+class TestDeviceOwnerReceiver : DeviceAdminReceiver() {
+    override fun onEnabled(context: Context, intent: Intent) {
+        super.onEnabled(context, intent)
+    }
+}

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow cleartext for local mock servers during debug/testing -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,8 +27,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
-        tools:targetApi="31"
-        tools:replace="android:theme,android:name,android:label">
+        tools:targetApi="31">
         
         <!-- Mobile Activity -->
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,12 +20,12 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -22,11 +22,10 @@ interface GeoIpApi {
 /**
  * Service to get current geographic region using freeipapi.com
  * Secure HTTPS is used to prevent unencrypted transmission of location data.
- * Using free.freeipapi.com subdomain for direct redirect-free access.
  */
 class GeoIpService {
     private val api = Retrofit.Builder()
-        .baseUrl("https://free.freeipapi.com/api/")
+        .baseUrl("https://freeipapi.com/api/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(GeoIpApi::class.java)

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -1,6 +1,7 @@
 package com.multiregionvpn.network
 
 import android.util.Log
+import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.Retrofit
@@ -8,9 +9,9 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 
 data class GeoIpResponse(
-    val countryCode: String?,
-    val country: String?,
-    val region: String?
+    @SerializedName("countryCode") val countryCode: String?,
+    @SerializedName("countryName") val country: String?,
+    @SerializedName("regionName") val region: String?
 )
 
 interface GeoIpApi {
@@ -19,11 +20,12 @@ interface GeoIpApi {
 }
 
 /**
- * Service to get current geographic region using ip-api.com
+ * Service to get current geographic region using freeipapi.com
+ * Secure HTTPS is used to prevent unencrypted transmission of location data.
  */
 class GeoIpService {
     private val api = Retrofit.Builder()
-        .baseUrl("http://ip-api.com/")
+        .baseUrl("https://freeipapi.com/api/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(GeoIpApi::class.java)

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -22,7 +22,7 @@ interface GeoIpApi {
 /**
  * Service to get current geographic region using freeipapi.com
  * Secure HTTPS is used to prevent unencrypted transmission of location data.
- * Using free.freeipapi.com subdomain for direct, redirect-free access.
+ * Using free.freeipapi.com subdomain for direct redirect-free access.
  */
 class GeoIpService {
     private val api = Retrofit.Builder()

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -22,10 +22,11 @@ interface GeoIpApi {
 /**
  * Service to get current geographic region using freeipapi.com
  * Secure HTTPS is used to prevent unencrypted transmission of location data.
+ * Using free.freeipapi.com subdomain for direct, redirect-free access.
  */
 class GeoIpService {
     private val api = Retrofit.Builder()
-        .baseUrl("https://freeipapi.com/api/")
+        .baseUrl("https://free.freeipapi.com/api/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(GeoIpApi::class.java)

--- a/app/src/main/java/com/multiregionvpn/ui/components/VpnHeaderBar.kt
+++ b/app/src/main/java/com/multiregionvpn/ui/components/VpnHeaderBar.kt
@@ -62,7 +62,8 @@ fun VpnHeaderBar(
                 Text(
                     text = "Region Router",
                     style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.SemiBold
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.testTag("Region Router")
                 )
             }
         },
@@ -134,4 +135,3 @@ enum class VpnStatus(val displayText: String) {
     DISCONNECTED("Disconnected"),
     ERROR("Error")
 }
-

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,14 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Allow cleartext traffic for testing with ip-api.com -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">ip-api.com</domain>
-    </domain-config>
+    <!-- Hardened configuration: only HTTPS is permitted for all domains -->
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
     </base-config>
 </network-security-config>
-
-


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application used an unencrypted HTTP endpoint (`http://ip-api.com`) for GeoIP lookups, which exposed user IP addresses and location data to MitM interception and spoofing.
🎯 **Impact:** An attacker could intercept geographic data or spoof location responses to manipulate VPN routing decisions or leak user metadata.
🔧 **Fix:** Migrated all GeoIP lookups to `https://freeipapi.com`, enforced HTTPS-only traffic via Android's Network Security Configuration, and disabled cleartext traffic in the production manifest. Also hardened the app by disabling `allowBackup`.
✅ **Verification:** Verified that `GeoIpService` and tests compile correctly. Confirmed `ip-api.com` references were removed. Validated manifest merger logic via Gradle.

---
*PR created automatically by Jules for task [11686666061198591402](https://jules.google.com/task/11686666061198591402) started by @thepont*