### PR TITLE
🛡️ Sentinel: [security improvement] Harden network security and backups

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Hardened Network Security and Secure GeoIP Migration
+**Vulnerability:** Cleartext traffic (HTTP) used for GeoIP lookups and allowed globally in manifest, plus insecure backups enabled.
+**Learning:** Default Android configurations and some free GeoIP providers (like ip-api.com free tier) lack HTTPS support, leading to MitM risks and manifest security gaps. Migrating to an HTTPS-capable provider (freeipapi.com) while hardening the manifest and network security config provides a layered defense.
+**Prevention:** Always use HTTPS for external API calls, disable cleartext traffic and backups in production manifests, and use debug overrides for testing. Use `@SerializedName` to maintain internal API compatibility when switching providers.

--- a/.maestro/07_verify_routing_with_chrome.yaml
+++ b/.maestro/07_verify_routing_with_chrome.yaml
@@ -35,12 +35,12 @@ appId: "com.multiregionvpn"
 - tapOn:
     id: "url_bar"
     optional: true
-- inputText: "ip-api.com/json"
+- inputText: "https://free.freeipapi.com/api/json"
 - pressKey: Enter
 
 # Wait for page to load (use a simple assertion with optional)
 - assertVisible:
-    text: ".*ip-api.*|United Kingdom|GB|country|city"
+    text: ".*freeipapi.*|United Kingdom|GB|countryName|cityName"
     optional: true
 
 # Look for "GB" in the page content (UK country code)

--- a/app/src/androidTest/java/com/multiregionvpn/DiagnosticRoutingTest.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/DiagnosticRoutingTest.kt
@@ -163,11 +163,11 @@ class DiagnosticRoutingTest {
         
         // Step 6: Make simple HTTP request
         println("\n6️⃣ Making HTTP request...")
-        println("   URL: http://ip-api.com/json")
+        println("   URL: https://free.freeipapi.com/api/json")
         println("   Expected: This request should go through VPN → UK servers")
         println("   Method: Direct HttpURLConnection (no Retrofit)")
         
-        val url = URL("http://ip-api.com/json")
+        val url = URL("https://free.freeipapi.com/api/json")
         val connection = url.openConnection() as HttpURLConnection
         connection.connectTimeout = 10000
         connection.readTimeout = 10000

--- a/app/src/androidTest/java/com/multiregionvpn/IpCheckService.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/IpCheckService.kt
@@ -9,14 +9,14 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.GET
 
 /**
- * Data class for the ip-api.com response
+ * Data class for the freeipapi.com response
  */
 @JsonClass(generateAdapter = true)
 data class IpInfo(
     @Json(name = "countryCode") val countryCode: String?,
-    @Json(name = "query") val ipAddress: String?,
-    @Json(name = "country") val country: String?,
-    @Json(name = "city") val city: String?
+    @Json(name = "ipAddress") val ipAddress: String?,
+    @Json(name = "countryName") val country: String?,
+    @Json(name = "cityName") val city: String?
 ) {
     val normalizedCountryCode: String?
         get() = countryCode
@@ -29,7 +29,7 @@ data class IpInfo(
  * Retrofit interface for IP geolocation checking
  */
 interface IpApiService {
-    @GET("/json")
+    @GET("json")
     suspend fun getIpInfo(): IpInfo
 }
 
@@ -41,13 +41,11 @@ object IpCheckService {
         .add(KotlinJsonAdapterFactory())
         .build()
 
-    // Use ip-api.com with HTTP (requires cleartext traffic enabled)
-    // The test manifest has android:usesCleartextTraffic="true"
+    // Security: Using HTTPS for GeoIP lookup in tests to match production hardening
     private val retrofit = Retrofit.Builder()
-        .baseUrl("http://ip-api.com/")
+        .baseUrl("https://free.freeipapi.com/api/")
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .build()
 
     val api: IpApiService = retrofit.create(IpApiService::class.java)
 }
-

--- a/app/src/androidTest/java/com/multiregionvpn/ProductionAppRoutingTest.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/ProductionAppRoutingTest.kt
@@ -184,7 +184,7 @@ class ProductionAppRoutingTest {
         println("\n5️⃣ MANUAL VERIFICATION REQUIRED:")
         println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
         println("1. Open Chrome on your device")
-        println("2. Navigate to: http://ip-api.com/json")
+        println("2. Navigate to: https://free.freeipapi.com/api/json")
         println("3. Check the 'countryCode' field")
         println("   ✅ Expected: \"GB\" (United Kingdom)")
         println("   ❌ If you see your local country, routing failed")
@@ -251,7 +251,7 @@ class ProductionAppRoutingTest {
         
         println("\n📊 VPN IS ACTIVE - Chrome should be in allowed apps")
         println("   To verify: Check logcat for 'ALLOWED: $CHROME_PACKAGE'")
-        println("   To test: Open Chrome and browse to http://ip-api.com/json")
+        println("   To test: Open Chrome and browse to https://free.freeipapi.com/api/json")
         println("   Expected: Packets from UID $chromeUid should appear in PacketRouter logs")
         println()
         println("Test will keep VPN active for 60 seconds for observation...")

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,6 +15,9 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:allowBackup="true"
+        android:usesCleartextTraffic="true"
+        tools:replace="android:allowBackup,android:usesCleartextTraffic"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,15 +20,15 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
-        tools:replace="android:theme,android:name,android:label">
+        tools:replace="android:theme,android:name,android:label,android:usesCleartextTraffic,android:allowBackup">
         
         <!-- Mobile Activity -->
         <activity

--- a/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
+++ b/app/src/main/java/com/multiregionvpn/network/GeoIpService.kt
@@ -1,6 +1,7 @@
 package com.multiregionvpn.network
 
 import android.util.Log
+import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.Retrofit
@@ -8,8 +9,11 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 
 data class GeoIpResponse(
+    @SerializedName("countryCode")
     val countryCode: String?,
+    @SerializedName("countryName")
     val country: String?,
+    @SerializedName("regionName")
     val region: String?
 )
 
@@ -19,11 +23,12 @@ interface GeoIpApi {
 }
 
 /**
- * Service to get current geographic region using ip-api.com
+ * Service to get current geographic region using freeipapi.com
  */
 class GeoIpService {
+    // Security: Using HTTPS for GeoIP lookup to prevent MITM attacks and tampering
     private val api = Retrofit.Builder()
-        .baseUrl("http://ip-api.com/")
+        .baseUrl("https://free.freeipapi.com/api/")
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(GeoIpApi::class.java)

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Allow cleartext traffic for testing with ip-api.com -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">ip-api.com</domain>
-    </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
     </base-config>
 </network-security-config>
-
-


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application was using cleartext traffic (HTTP) for GeoIP lookups and had `android:usesCleartextTraffic` and `android:allowBackup` enabled in the main manifest. The existing GeoIP provider (ip-api.com) does not support HTTPS on its free tier.
🎯 Impact: Unencrypted traffic is vulnerable to Man-in-the-Middle (MitM) attacks, potentially allowing attackers to spoof geolocation data. Enabling backups allows sensitive data (like VPN credentials) to be extracted via ADB.
🔧 Fix:
1. Hardened `app/src/main/AndroidManifest.xml` by setting `android:usesCleartextTraffic="false"` and `android:allowBackup="false"`.
2. Updated `app/src/main/res/xml/network_security_config.xml` to prohibit cleartext traffic globally.
3. Migrated `GeoIpService.kt` to use `freeipapi.com` which supports HTTPS for free. Used `@SerializedName` to maintain internal compatibility.
4. Updated `IpCheckService.kt` and instrumented tests to use secure HTTPS endpoints.
5. Added a debug manifest (`app/src/debug/AndroidManifest.xml`) with `tools:replace` to allow cleartext and backups ONLY during development and testing.
✅ Verification: Successfully verified that the application and all test source sets (unit and instrumented) compile using `./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin :app:compileDebugAndroidTestKotlin -PSKIP_NATIVE_BUILD=true -x compileDebugJavaWithJavac -x compileReleaseJavaWithJavac -x hiltAggregateDepsDebug`.

---
*PR created automatically by Jules for task [10856933247622864554](https://jules.google.com/task/10856933247622864554) started by @thepont*