### PR TITLE
🛡️ Sentinel: [HIGH] Fix Insecure Plaintext Credential Temporary Storage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-08 - [Insecure Temporary Credentials Storage]
+**Vulnerability:** The application writes OpenVPN credentials in plaintext to temporary files in `context.cacheDir` so the native OpenVPN client can configure connection profiles, but leaves them lingering indefinitely on disk after connection setup.
+**Learning:** Temporary plaintext files are often created during bridge integration but are easily forgotten. Although private to the application on Android, leaving credentials permanently stored in plaintext on disk exposes them to offline attacks, backup extractions, or security configuration bypasses.
+**Prevention:** Always read credentials from temporary files directly into memory as early as possible and delete the files immediately. Use a try-finally block in the consuming method to guarantee cleanup regardless of success, failure, or exceptions.

--- a/app/src/androidTest/java/com/multiregionvpn/core/vpnclient/NativeOpenVpnClientIntegrationTest.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/core/vpnclient/NativeOpenVpnClientIntegrationTest.kt
@@ -284,5 +284,32 @@ class NativeOpenVpnClientIntegrationTest {
         // Should still be functional
         assertThat(client.isConnected()).isFalse()
     }
+
+    /**
+     * Security verification test: verify that the temporary plaintext credentials
+     * file passed to the client is deleted immediately after connection initialization.
+     */
+    @Test
+    fun test_connect_deletesAuthFileImmediately() {
+        // GIVEN: A client and a temporary credentials file
+        val client = NativeOpenVpnClient(appContext, mockVpnService)
+        val tempAuthFile = java.io.File(appContext.cacheDir, "test_temp_auth_${System.currentTimeMillis()}.txt")
+        tempAuthFile.writeText("test_user\ntest_password\n", Charsets.UTF_8)
+
+        assertThat(tempAuthFile.exists()).isTrue()
+
+        // WHEN: Calling connect (it might fail because of invalid config or lack of a real connection)
+        val dummyConfig = "client\nremote 127.0.0.1 1194\nproto udp\n"
+        runBlocking {
+            try {
+                client.connect(dummyConfig, tempAuthFile.absolutePath)
+            } catch (e: Exception) {
+                // Expected to fail, or not, depending on native execution, but we ignore exceptions
+            }
+        }
+
+        // THEN: The temporary plaintext credentials file MUST have been deleted from disk immediately
+        assertThat(tempAuthFile.exists()).isFalse()
+    }
 }
 

--- a/app/src/main/java/com/multiregionvpn/core/vpnclient/NativeOpenVpnClient.kt
+++ b/app/src/main/java/com/multiregionvpn/core/vpnclient/NativeOpenVpnClient.kt
@@ -133,40 +133,52 @@ class NativeOpenVpnClient(
                 if (authFilePath != null) {
                     val authFile = java.io.File(authFilePath)
                     if (authFile.exists()) {
-                        // Read file as UTF-8 (OpenVPN expects UTF-8)
-                        // readLines() uses UTF-8 by default, which is correct
-                        val lines = authFile.readLines(Charsets.UTF_8)
-                        if (lines.size >= 2) {
-                            username = lines[0].trim()
-                            password = lines[1].trim()
-                            
-                            // Verify credentials are not empty
-                            if (username.isEmpty() || password.isEmpty()) {
-                                Log.e(TAG, "❌ Credentials are empty after reading from auth file")
-                                Log.e(TAG, "   Username length: ${username.length}, Password length: ${password.length}")
+                        try {
+                            // Read file as UTF-8 (OpenVPN expects UTF-8)
+                            // readLines() uses UTF-8 by default, which is correct
+                            val lines = authFile.readLines(Charsets.UTF_8)
+                            if (lines.size >= 2) {
+                                username = lines[0].trim()
+                                password = lines[1].trim()
+
+                                // Verify credentials are not empty
+                                if (username.isEmpty() || password.isEmpty()) {
+                                    Log.e(TAG, "❌ Credentials are empty after reading from auth file")
+                                    Log.e(TAG, "   Username length: ${username.length}, Password length: ${password.length}")
+                                    return@withContext false
+                                }
+
+                                // Log encoding info (without exposing actual credentials)
+                                val usernameBytes = username.toByteArray(Charsets.UTF_8)
+                                val passwordBytes = password.toByteArray(Charsets.UTF_8)
+                                Log.d(TAG, "Credentials loaded from auth file (UTF-8):")
+                                Log.d(TAG, "   Username: ${username.length} chars, ${usernameBytes.size} UTF-8 bytes")
+                                Log.d(TAG, "   Password: ${password.length} chars, ${passwordBytes.size} UTF-8 bytes")
+
+                                // Verify UTF-8 encoding is valid
+                                try {
+                                    // Attempt to decode as UTF-8 to verify encoding
+                                    String(usernameBytes, Charsets.UTF_8)
+                                    String(passwordBytes, Charsets.UTF_8)
+                                    Log.d(TAG, "✅ Credentials are valid UTF-8 strings")
+                                } catch (e: Exception) {
+                                    Log.e(TAG, "❌ Invalid UTF-8 encoding in credentials", e)
+                                    return@withContext false
+                                }
+                            } else {
+                                Log.e(TAG, "❌ Auth file does not contain username/password (lines: ${lines.size})")
                                 return@withContext false
                             }
-                            
-                            // Log encoding info (without exposing actual credentials)
-                            val usernameBytes = username.toByteArray(Charsets.UTF_8)
-                            val passwordBytes = password.toByteArray(Charsets.UTF_8)
-                            Log.d(TAG, "Credentials loaded from auth file (UTF-8):")
-                            Log.d(TAG, "   Username: ${username.length} chars, ${usernameBytes.size} UTF-8 bytes")
-                            Log.d(TAG, "   Password: ${password.length} chars, ${passwordBytes.size} UTF-8 bytes")
-                            
-                            // Verify UTF-8 encoding is valid
+                        } finally {
+                            // SECURE COMPLIANCE: Delete the temporary plaintext auth file immediately after reading
                             try {
-                                // Attempt to decode as UTF-8 to verify encoding
-                                String(usernameBytes, Charsets.UTF_8)
-                                String(passwordBytes, Charsets.UTF_8)
-                                Log.d(TAG, "✅ Credentials are valid UTF-8 strings")
+                                if (authFile.exists()) {
+                                    val deleted = authFile.delete()
+                                    Log.d(TAG, "🧹 Temporary credentials file deleted immediately after reading: $deleted")
+                                }
                             } catch (e: Exception) {
-                                Log.e(TAG, "❌ Invalid UTF-8 encoding in credentials", e)
-                                return@withContext false
+                                Log.w(TAG, "⚠️ Failed to delete temporary credentials file: ${e.message}")
                             }
-                        } else {
-                            Log.e(TAG, "❌ Auth file does not contain username/password (lines: ${lines.size})")
-                            return@withContext false
                         }
                     } else {
                         Log.e(TAG, "❌ Auth file does not exist: $authFilePath")


### PR DESCRIPTION
### Description
* 🚨 **Severity:** HIGH
* 💡 **Vulnerability:** **Insecure Storage of Plaintext Credentials on Disk (CWE-312)**. The application generates temporary auth `.txt` files containing NordVPN and local-test service credentials in plaintext inside `context.cacheDir`. However, after connection setup, these files are left on disk indefinitely.
* 🎯 **Impact:** If a device is compromised, backup utilities are run, or application sandbox directories are accessed, the plaintext service credentials for the VPN are permanently readable on the local storage.
* 🔧 **Fix:** Hardened `NativeOpenVpnClient.connect()` by introducing a `try-finally` block around the UTF-8 file reading logic. This guarantees that as soon as the credentials are read into memory variables, the temporary `.txt` file is deleted immediately, minimizing the persistence window of plaintext secrets on disk to almost zero.
* ✅ **Verification:** Added an integration test `test_connect_deletesAuthFileImmediately()` inside `NativeOpenVpnClientIntegrationTest.kt` which creates a mock temporary auth file, invokes connection, and asserts that the file is deleted immediately. Verified that all sources and tests compile flawlessly.

---
*PR created automatically by Jules for task [14469064722789826363](https://jules.google.com/task/14469064722789826363) started by @thepont*