### PR TITLE
🛡️ Sentinel: [HIGH] Fix Insecure Plaintext Credential Temporary Storage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal
+
+## 2026-03-02 - Insecure Plaintext Credential Temporary Storage
+**Vulnerability:** Plaintext VPN credentials (username and password) were written to a temporary auth file in the application's cache directory during tunnel preparation but were never cleaned up. This left sensitive, unencrypted credentials lingering indefinitely on the filesystem.
+**Learning:** OpenVPN 3 C++ library requires credentials to be supplied, and a common way to achieve this on Android is writing them to a temporary file for the library's file reader. However, if the application does not explicitly delete this file, the credentials linger in the internal storage cache directory, risking exposure to backup extraction, local file read vulnerabilities, or compromised root environments.
+**Prevention:** Always delete temporary credentials files immediately after their contents are read into JVM memory or passed to the native layer. Wrapping the file reading logic in a `try-finally` block guarantees that the sensitive file is securely deleted from disk, even if execution throws an exception or returns early.

--- a/app/src/androidTest/java/com/multiregionvpn/core/vpnclient/NativeOpenVpnClientIntegrationTest.kt
+++ b/app/src/androidTest/java/com/multiregionvpn/core/vpnclient/NativeOpenVpnClientIntegrationTest.kt
@@ -284,5 +284,31 @@ class NativeOpenVpnClientIntegrationTest {
         // Should still be functional
         assertThat(client.isConnected()).isFalse()
     }
+
+    /**
+     * SEC-ENH: Verify that NativeOpenVpnClient.connect() immediately deletes
+     * the temporary plaintext credentials file from context.cacheDir after reading it into memory.
+     */
+    @Test
+    fun test_connect_deletesAuthFileImmediately() {
+        // GIVEN: A temporary auth file containing plain text credentials
+        val authFile = java.io.File(appContext.cacheDir, "test_auth_temp.txt")
+        authFile.writeText("test_user\ntest_pass\n", Charsets.UTF_8)
+        assertThat(authFile.exists()).isTrue()
+
+        val client = NativeOpenVpnClient(appContext, mockVpnService)
+
+        // WHEN: Calling connect (may fail or throw due to dummy config, but finally block must run)
+        try {
+            runBlocking {
+                client.connect("dummy_config", authFile.absolutePath)
+            }
+        } catch (e: Exception) {
+            // Ignore any configuration or connection errors
+        }
+
+        // THEN: The temporary auth file is securely deleted immediately
+        assertThat(authFile.exists()).isFalse()
+    }
 }
 

--- a/app/src/main/java/com/multiregionvpn/core/vpnclient/NativeOpenVpnClient.kt
+++ b/app/src/main/java/com/multiregionvpn/core/vpnclient/NativeOpenVpnClient.kt
@@ -132,45 +132,28 @@ class NativeOpenVpnClient(
                 
                 if (authFilePath != null) {
                     val authFile = java.io.File(authFilePath)
-                    if (authFile.exists()) {
-                        // Read file as UTF-8 (OpenVPN expects UTF-8)
-                        // readLines() uses UTF-8 by default, which is correct
-                        val lines = authFile.readLines(Charsets.UTF_8)
-                        if (lines.size >= 2) {
-                            username = lines[0].trim()
-                            password = lines[1].trim()
-                            
-                            // Verify credentials are not empty
-                            if (username.isEmpty() || password.isEmpty()) {
-                                Log.e(TAG, "❌ Credentials are empty after reading from auth file")
-                                Log.e(TAG, "   Username length: ${username.length}, Password length: ${password.length}")
-                                return@withContext false
-                            }
-                            
-                            // Log encoding info (without exposing actual credentials)
-                            val usernameBytes = username.toByteArray(Charsets.UTF_8)
-                            val passwordBytes = password.toByteArray(Charsets.UTF_8)
-                            Log.d(TAG, "Credentials loaded from auth file (UTF-8):")
-                            Log.d(TAG, "   Username: ${username.length} chars, ${usernameBytes.size} UTF-8 bytes")
-                            Log.d(TAG, "   Password: ${password.length} chars, ${passwordBytes.size} UTF-8 bytes")
-                            
-                            // Verify UTF-8 encoding is valid
-                            try {
-                                // Attempt to decode as UTF-8 to verify encoding
-                                String(usernameBytes, Charsets.UTF_8)
-                                String(passwordBytes, Charsets.UTF_8)
-                                Log.d(TAG, "✅ Credentials are valid UTF-8 strings")
-                            } catch (e: Exception) {
-                                Log.e(TAG, "❌ Invalid UTF-8 encoding in credentials", e)
-                                return@withContext false
-                            }
-                        } else {
-                            Log.e(TAG, "❌ Auth file does not contain username/password (lines: ${lines.size})")
+                    try {
+                        if (!authFile.exists()) {
+                            Log.e(TAG, "❌ Auth file does not exist: $authFilePath")
                             return@withContext false
                         }
-                    } else {
-                        Log.e(TAG, "❌ Auth file does not exist: $authFilePath")
-                        return@withContext false
+                        val lines = authFile.readLines(Charsets.UTF_8)
+                        if (lines.size < 2) {
+                            Log.e(TAG, "❌ Auth file does not contain username/password")
+                            return@withContext false
+                        }
+                        username = lines[0].trim()
+                        password = lines[1].trim()
+
+                        if (username.isEmpty() || password.isEmpty()) {
+                            Log.e(TAG, "❌ Credentials are empty after reading from auth file")
+                            return@withContext false
+                        }
+                    } finally {
+                        // SEC-ENH: Securely delete the temporary plaintext auth file immediately after reading (defense-in-depth)
+                        if (authFile.exists() && authFile.delete()) {
+                            Log.d(TAG, "🔒 Temporary auth file deleted: $authFilePath")
+                        }
                     }
                 } else {
                     Log.e(TAG, "❌ No auth file provided")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Insecure Plaintext Credential Temporary Storage
🎯 Impact: Plaintext VPN credentials (username/password) stored in temporary files inside context.cacheDir would linger indefinitely on the filesystem, exposing them to potential data harvesting from backups, compromised local environments, or file traversal attacks.
🔧 Fix: Wrapped the credential file reading logic in `NativeOpenVpnClient.connect()` inside a `try-finally` block to guarantee that the temporary plaintext file is securely and immediately deleted from disk once its contents are read into JVM memory.
✅ Verification: Added a dedicated integration test `test_connect_deletesAuthFileImmediately()` inside `NativeOpenVpnClientIntegrationTest.kt` to assert that the file is successfully deleted after `connect()` is executed. Verified successful compilation via Kotlin-specific gradle compilation tasks.

---
*PR created automatically by Jules for task [14601226264176451397](https://jules.google.com/task/14601226264176451397) started by @thepont*