### PR TITLE
🛡️ Sentinel: [HIGH] Fix cleartext traffic and backup vulnerability in manifest

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -15,6 +15,9 @@
         tools:ignore="ProtectedPermissions" />
 
     <application
+        android:allowBackup="true"
+        android:usesCleartextTraffic="true"
+        tools:replace="android:allowBackup,android:usesCleartextTraffic"
         tools:ignore="MissingLeanbackLauncher">
         <receiver
             android:name=".deviceowner.TestDeviceOwnerReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,14 +18,17 @@
         android:name="android.hardware.touchscreen"
         android:required="false" />
 
+    <!-- Security Hardening:
+         - allowBackup="false": Prevents sensitive VPN credentials and app data from ADB/cloud backup.
+         - usesCleartextTraffic="false": Enforces TLS encrypted traffic for production. -->
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.MultiRegionVPN"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:banner="@drawable/tv_banner"
         tools:targetApi="31"
         tools:replace="android:theme,android:name,android:label">


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Application enabled ADB/cloud backup (`android:allowBackup="true"`) and allowed unencrypted cleartext HTTP traffic (`android:usesCleartextTraffic="true"`) in the production manifest.
🎯 Impact: Attackers with physical/ADB access could extract sensitive credentials and VPN configuration data via Android backup tools, and network eavesdroppers could intercept cleartext HTTP traffic.
🔧 Fix: Updated `app/src/main/AndroidManifest.xml` to set `android:allowBackup="false"` and `android:usesCleartextTraffic="false"`. Updated `app/src/debug/AndroidManifest.xml` with `tools:replace` to preserve debug and E2E test server compatibility.
✅ Verification: Executed `./gradlew --rerun-tasks :app:compileDebugKotlin :app:compileDebugUnitTestKotlin :app:compileDebugAndroidTestKotlin -PSKIP_NATIVE_BUILD=true -x compileDebugJavaWithJavac -x compileReleaseJavaWithJavac -x hiltAggregateDepsDebug` to verify manifest merging and clean compilation.

---
*PR created automatically by Jules for task [11476477440919144057](https://jules.google.com/task/11476477440919144057) started by @thepont*